### PR TITLE
26 change sample sdk references

### DIFF
--- a/FBWinSDK/FBSDK-UWP/FBSDK-UWP/FBSDK-UWP.vcxproj
+++ b/FBWinSDK/FBSDK-UWP/FBSDK-UWP/FBSDK-UWP.vcxproj
@@ -36,6 +36,8 @@
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <ApplicationTypeRevision>8.2</ApplicationTypeRevision>
+    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/FBWinSDK/FBWinSDK/FBWinSDK.Shared/FacebookSession.cpp
+++ b/FBWinSDK/FBWinSDK/FBWinSDK.Shared/FacebookSession.cpp
@@ -315,9 +315,21 @@ task<FBResult^> FBSession::CheckForExistingToken(
             }
             return decryptTask;
         })
-        .then([](IBuffer^ clearBuffer) -> FBResult^
+        .then([](task<IBuffer^> clearBufferTask) -> FBResult^
         {
             FBResult^ cachedResult = nullptr;
+			IBuffer^ clearBuffer = nullptr;
+
+			try
+			{
+				clearBuffer = clearBufferTask.get();
+			}
+			catch (InvalidArgumentException^ ex)
+			{
+#ifdef _DEBUG
+				OutputDebugString(L"Couldn't decrypt cached token.  Continuing without cached token data.\n");
+#endif
+			}
 
             if (clearBuffer)
             {

--- a/FBWinSDK/FBWinSDK/FBWinSDK.Windows/FBWinSDK.Windows.vcxproj
+++ b/FBWinSDK/FBWinSDK/FBWinSDK.Windows/FBWinSDK.Windows.vcxproj
@@ -98,9 +98,7 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="FBWinSDK.props" />
   </ImportGroup>
-  <PropertyGroup Label="UserMacros">
-    <NuGetPackageImportStamp>6e7a1c1d</NuGetPackageImportStamp>
-  </PropertyGroup>
+  <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <GenerateManifest>false</GenerateManifest>
     <PreBuildEventUseInBuild>true</PreBuildEventUseInBuild>

--- a/FBWinSDK/FBWinSDK/FBWinSDK.WindowsPhone/FBWinSDK.WindowsPhone.vcxproj
+++ b/FBWinSDK/FBWinSDK/FBWinSDK.WindowsPhone/FBWinSDK.WindowsPhone.vcxproj
@@ -27,7 +27,6 @@
     <ApplicationType>Windows Phone</ApplicationType>
     <ApplicationTypeRevision>8.1</ApplicationTypeRevision>
     <ConvergedProjectType>CodeSharingWindowsRuntimeComponent</ConvergedProjectType>
-    <NuGetPackageImportStamp>5b8e8f0c</NuGetPackageImportStamp>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
   </PropertyGroup>

--- a/FBWinSDK/build/build-sdk.cmd
+++ b/FBWinSDK/build/build-sdk.cmd
@@ -26,7 +26,7 @@ if errorlevel 1 goto errorExit
 
 call :build_one_flavor FBWinSDK.sln Win32 Release 
 if errorlevel 1 goto errorExit
-k
+
 call :build_one_flavor FBWinSDK.sln x64 Debug 
 if errorlevel 1 goto errorExit
 

--- a/samples/LoginCpp-UWP/LoginCpp-UWP.sln
+++ b/samples/LoginCpp-UWP/LoginCpp-UWP.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 14.0.22823.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "LoginCpp", "LoginCpp\LoginCpp.vcxproj", "{351701A8-12D1-45B3-8E6A-164D796B0297}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Facebook", "..\..\FBWinSDK\FBSDK-UWP\FBSDK-UWP\FBSDK-UWP.vcxproj", "{973A943B-FF77-4267-8F30-F5FE2B7F5583}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|ARM = Debug|ARM
@@ -33,6 +35,18 @@ Global
 		{351701A8-12D1-45B3-8E6A-164D796B0297}.Release|x86.ActiveCfg = Release|Win32
 		{351701A8-12D1-45B3-8E6A-164D796B0297}.Release|x86.Build.0 = Release|Win32
 		{351701A8-12D1-45B3-8E6A-164D796B0297}.Release|x86.Deploy.0 = Release|Win32
+		{973A943B-FF77-4267-8F30-F5FE2B7F5583}.Debug|ARM.ActiveCfg = Debug|ARM
+		{973A943B-FF77-4267-8F30-F5FE2B7F5583}.Debug|ARM.Build.0 = Debug|ARM
+		{973A943B-FF77-4267-8F30-F5FE2B7F5583}.Debug|x64.ActiveCfg = Debug|x64
+		{973A943B-FF77-4267-8F30-F5FE2B7F5583}.Debug|x64.Build.0 = Debug|x64
+		{973A943B-FF77-4267-8F30-F5FE2B7F5583}.Debug|x86.ActiveCfg = Debug|Win32
+		{973A943B-FF77-4267-8F30-F5FE2B7F5583}.Debug|x86.Build.0 = Debug|Win32
+		{973A943B-FF77-4267-8F30-F5FE2B7F5583}.Release|ARM.ActiveCfg = Release|ARM
+		{973A943B-FF77-4267-8F30-F5FE2B7F5583}.Release|ARM.Build.0 = Release|ARM
+		{973A943B-FF77-4267-8F30-F5FE2B7F5583}.Release|x64.ActiveCfg = Release|x64
+		{973A943B-FF77-4267-8F30-F5FE2B7F5583}.Release|x64.Build.0 = Release|x64
+		{973A943B-FF77-4267-8F30-F5FE2B7F5583}.Release|x86.ActiveCfg = Release|Win32
+		{973A943B-FF77-4267-8F30-F5FE2B7F5583}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/samples/LoginCpp-UWP/LoginCpp/LoginCpp.vcxproj
+++ b/samples/LoginCpp-UWP/LoginCpp/LoginCpp.vcxproj
@@ -8,6 +8,8 @@
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <ApplicationTypeRevision>8.2</ApplicationTypeRevision>
+    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <ItemGroup Label="ProjectConfigurations">

--- a/samples/LoginCpp-UWP/LoginCpp/LoginCpp.vcxproj
+++ b/samples/LoginCpp-UWP/LoginCpp/LoginCpp.vcxproj
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\FBWinSDK.0.9.0\build\native\FBWinSDK.props" Condition="Exists('..\packages\FBWinSDK.0.9.0\build\native\FBWinSDK.props')" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>{351701a8-12d1-45b3-8e6a-164d796b0297}</ProjectGuid>
     <RootNamespace>LoginCpp</RootNamespace>
@@ -173,7 +172,6 @@
       <SubType>Designer</SubType>
     </AppxManifest>
     <None Include="LoginCpp_TemporaryKey.pfx" />
-    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <Image Include="Assets\Logo.scale-100.png" />
@@ -217,15 +215,11 @@
   <ItemGroup>
     <PRIResource Include="Resources.resw" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\FBWinSDK\FBSDK-UWP\FBSDK-UWP\FBSDK-UWP.vcxproj">
+      <Project>{973a943b-ff77-4267-8f30-f5fe2b7f5583}</Project>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-  <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\packages\FBWinSDK.0.9.0\build\native\FBWinSDK.targets" Condition="Exists('..\packages\FBWinSDK.0.9.0\build\native\FBWinSDK.targets')" />
-  </ImportGroup>
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\FBWinSDK.0.9.0\build\native\FBWinSDK.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\FBWinSDK.0.9.0\build\native\FBWinSDK.props'))" />
-    <Error Condition="!Exists('..\packages\FBWinSDK.0.9.0\build\native\FBWinSDK.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\FBWinSDK.0.9.0\build\native\FBWinSDK.targets'))" />
-  </Target>
+  <ImportGroup Label="ExtensionTargets" />
 </Project>

--- a/samples/LoginCpp-UWP/LoginCpp/LoginCpp.vcxproj.filters
+++ b/samples/LoginCpp-UWP/LoginCpp/LoginCpp.vcxproj.filters
@@ -60,7 +60,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="LoginCpp_TemporaryKey.pfx" />
-    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <Page Include="MainPage.xaml" />

--- a/samples/LoginCpp-UWP/LoginCpp/packages.config
+++ b/samples/LoginCpp-UWP/LoginCpp/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="FBWinSDK" version="0.9.0" targetFramework="native" userInstalled="true" />
-</packages>

--- a/samples/LoginCpp/LoginCpp.sln
+++ b/samples/LoginCpp/LoginCpp.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.23107.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "LoginCpp", "LoginCpp", "{47BA2ADD-38F5-4219-9C6F-0B2A99667255}"
 EndProject
@@ -18,9 +18,15 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{A2C873
 		.nuget\NuGet.targets = .nuget\NuGet.targets
 	EndProjectSection
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "FBWinSDK.Windows", "..\..\FBWinSDK\FBWinSDK\FBWinSDK.Windows\FBWinSDK.Windows.vcxproj", "{418FC79B-AA0F-4951-A7D9-7DA89BDF8FB6}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "FBWinSDK.WindowsPhone", "..\..\FBWinSDK\FBWinSDK\FBWinSDK.WindowsPhone\FBWinSDK.WindowsPhone.vcxproj", "{F833B1E6-2866-4A47-89E2-C474983FE70F}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		LoginCpp\LoginCpp.Shared\LoginCpp.Shared.vcxitems*{079ac050-7d48-41f0-83c2-f4c4da7f21d4}*SharedItemsImports = 9
+		..\..\FBWinSDK\FBWinSDK\FBWinSDK.Shared\FBWinSDK.Shared.vcxitems*{418fc79b-aa0f-4951-a7d9-7da89bdf8fb6}*SharedItemsImports = 4
+		..\..\FBWinSDK\FBWinSDK\FBWinSDK.Shared\FBWinSDK.Shared.vcxitems*{f833b1e6-2866-4a47-89e2-c474983fe70f}*SharedItemsImports = 4
 		LoginCpp\LoginCpp.Shared\LoginCpp.Shared.vcxitems*{45baa3ab-92f6-4db0-b008-fddd73d1659b}*SharedItemsImports = 4
 		LoginCpp\LoginCpp.Shared\LoginCpp.Shared.vcxitems*{4fdef5bd-ed11-49a1-b6c6-d9f0ab7eb7e2}*SharedItemsImports = 4
 	EndGlobalSection
@@ -65,6 +71,28 @@ Global
 		{45BAA3AB-92F6-4DB0-B008-FDDD73D1659B}.Release|Win32.Build.0 = Release|Win32
 		{45BAA3AB-92F6-4DB0-B008-FDDD73D1659B}.Release|Win32.Deploy.0 = Release|Win32
 		{45BAA3AB-92F6-4DB0-B008-FDDD73D1659B}.Release|x64.ActiveCfg = Release|Win32
+		{418FC79B-AA0F-4951-A7D9-7DA89BDF8FB6}.Debug|ARM.ActiveCfg = Debug|ARM
+		{418FC79B-AA0F-4951-A7D9-7DA89BDF8FB6}.Debug|ARM.Build.0 = Debug|ARM
+		{418FC79B-AA0F-4951-A7D9-7DA89BDF8FB6}.Debug|Win32.ActiveCfg = Debug|Win32
+		{418FC79B-AA0F-4951-A7D9-7DA89BDF8FB6}.Debug|Win32.Build.0 = Debug|Win32
+		{418FC79B-AA0F-4951-A7D9-7DA89BDF8FB6}.Debug|x64.ActiveCfg = Debug|x64
+		{418FC79B-AA0F-4951-A7D9-7DA89BDF8FB6}.Debug|x64.Build.0 = Debug|x64
+		{418FC79B-AA0F-4951-A7D9-7DA89BDF8FB6}.Release|ARM.ActiveCfg = Release|ARM
+		{418FC79B-AA0F-4951-A7D9-7DA89BDF8FB6}.Release|ARM.Build.0 = Release|ARM
+		{418FC79B-AA0F-4951-A7D9-7DA89BDF8FB6}.Release|Win32.ActiveCfg = Release|Win32
+		{418FC79B-AA0F-4951-A7D9-7DA89BDF8FB6}.Release|Win32.Build.0 = Release|Win32
+		{418FC79B-AA0F-4951-A7D9-7DA89BDF8FB6}.Release|x64.ActiveCfg = Release|x64
+		{418FC79B-AA0F-4951-A7D9-7DA89BDF8FB6}.Release|x64.Build.0 = Release|x64
+		{F833B1E6-2866-4A47-89E2-C474983FE70F}.Debug|ARM.ActiveCfg = Debug|ARM
+		{F833B1E6-2866-4A47-89E2-C474983FE70F}.Debug|ARM.Build.0 = Debug|ARM
+		{F833B1E6-2866-4A47-89E2-C474983FE70F}.Debug|Win32.ActiveCfg = Debug|Win32
+		{F833B1E6-2866-4A47-89E2-C474983FE70F}.Debug|Win32.Build.0 = Debug|Win32
+		{F833B1E6-2866-4A47-89E2-C474983FE70F}.Debug|x64.ActiveCfg = Debug|Win32
+		{F833B1E6-2866-4A47-89E2-C474983FE70F}.Release|ARM.ActiveCfg = Release|ARM
+		{F833B1E6-2866-4A47-89E2-C474983FE70F}.Release|ARM.Build.0 = Release|ARM
+		{F833B1E6-2866-4A47-89E2-C474983FE70F}.Release|Win32.ActiveCfg = Release|Win32
+		{F833B1E6-2866-4A47-89E2-C474983FE70F}.Release|Win32.Build.0 = Release|Win32
+		{F833B1E6-2866-4A47-89E2-C474983FE70F}.Release|x64.ActiveCfg = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/samples/LoginCpp/LoginCpp/LoginCpp.Windows/LoginCpp.Windows.vcxproj
+++ b/samples/LoginCpp/LoginCpp/LoginCpp.Windows/LoginCpp.Windows.vcxproj
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\FBWinSDK.0.9.0\build\native\FBWinSDK.props" Condition="Exists('..\..\packages\FBWinSDK.0.9.0\build\native\FBWinSDK.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|ARM">
       <Configuration>Debug</Configuration>
@@ -97,7 +96,6 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <PackageCertificateKeyFile>LoginCpp.Windows_TemporaryKey.pfx</PackageCertificateKeyFile>
-    <NuGetPackageImportStamp>549b9e9f</NuGetPackageImportStamp>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
     <ClCompile>
@@ -165,7 +163,6 @@
       <SubType>Designer</SubType>
     </AppxManifest>
     <None Include="LoginCpp.Windows_TemporaryKey.pfx" />
-    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <Image Include="Assets\Logo.scale-100.png" />
@@ -187,17 +184,19 @@
       <DependentUpon>OptionsPage.xaml</DependentUpon>
     </ClCompile>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\FBWinSDK\FBWinSDK\FBWinSDK.Windows\FBWinSDK.Windows.vcxproj">
+      <Project>{418fc79b-aa0f-4951-a7d9-7da89bdf8fb6}</Project>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
-    <Import Project="..\..\packages\FBWinSDK.0.9.0\build\native\FBWinSDK.targets" Condition="Exists('..\..\packages\FBWinSDK.0.9.0\build\native\FBWinSDK.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
-    <Error Condition="!Exists('..\..\packages\FBWinSDK.0.9.0\build\native\FBWinSDK.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\FBWinSDK.0.9.0\build\native\FBWinSDK.props'))" />
-    <Error Condition="!Exists('..\..\packages\FBWinSDK.0.9.0\build\native\FBWinSDK.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\FBWinSDK.0.9.0\build\native\FBWinSDK.targets'))" />
   </Target>
 </Project>

--- a/samples/LoginCpp/LoginCpp/LoginCpp.Windows/LoginCpp.Windows.vcxproj.filters
+++ b/samples/LoginCpp/LoginCpp/LoginCpp.Windows/LoginCpp.Windows.vcxproj.filters
@@ -25,6 +25,8 @@
     <ClCompile Include="Common\SuspensionManager.cpp">
       <Filter>Common</Filter>
     </ClCompile>
+    <ClCompile Include="Dialogs.xaml.cpp" />
+    <ClCompile Include="OptionsPage.xaml.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="MainPage.xaml.h" />
@@ -37,13 +39,14 @@
     <ClInclude Include="Common\SuspensionManager.h">
       <Filter>Common</Filter>
     </ClInclude>
+    <ClInclude Include="Dialogs.xaml.h" />
+    <ClInclude Include="OptionsPage.xaml.h" />
   </ItemGroup>
   <ItemGroup>
     <AppxManifest Include="Package.appxmanifest" />
   </ItemGroup>
   <ItemGroup>
     <None Include="LoginCpp.Windows_TemporaryKey.pfx" />
-    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <Image Include="Assets\Logo.scale-100.png">

--- a/samples/LoginCpp/LoginCpp/LoginCpp.Windows/packages.config
+++ b/samples/LoginCpp/LoginCpp/LoginCpp.Windows/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="FBWinSDK" version="0.9.0" targetFramework="Native" />
-</packages>

--- a/samples/LoginCpp/LoginCpp/LoginCpp.WindowsPhone/LoginCpp.WindowsPhone.vcxproj
+++ b/samples/LoginCpp/LoginCpp/LoginCpp.WindowsPhone/LoginCpp.WindowsPhone.vcxproj
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\FBWinSDK.0.9.0\build\native\FBWinSDK.props" Condition="Exists('..\..\packages\FBWinSDK.0.9.0\build\native\FBWinSDK.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|ARM">
       <Configuration>Debug</Configuration>
@@ -69,9 +68,7 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <PropertyGroup Label="UserMacros">
-    <NuGetPackageImportStamp>1a559eac</NuGetPackageImportStamp>
-  </PropertyGroup>
+  <PropertyGroup Label="UserMacros" />
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
     <ClCompile>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
@@ -147,19 +144,18 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <ProjectReference Include="..\..\..\..\FBWinSDK\FBWinSDK\FBWinSDK.WindowsPhone\FBWinSDK.WindowsPhone.vcxproj">
+      <Project>{f833b1e6-2866-4a47-89e2-c474983fe70f}</Project>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
-    <Import Project="..\..\packages\FBWinSDK.0.9.0\build\native\FBWinSDK.targets" Condition="Exists('..\..\packages\FBWinSDK.0.9.0\build\native\FBWinSDK.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
-    <Error Condition="!Exists('..\..\packages\FBWinSDK.0.9.0\build\native\FBWinSDK.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\FBWinSDK.0.9.0\build\native\FBWinSDK.props'))" />
-    <Error Condition="!Exists('..\..\packages\FBWinSDK.0.9.0\build\native\FBWinSDK.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\FBWinSDK.0.9.0\build\native\FBWinSDK.targets'))" />
   </Target>
 </Project>

--- a/samples/LoginCpp/LoginCpp/LoginCpp.WindowsPhone/LoginCpp.WindowsPhone.vcxproj.filters
+++ b/samples/LoginCpp/LoginCpp/LoginCpp.WindowsPhone/LoginCpp.WindowsPhone.vcxproj.filters
@@ -63,7 +63,4 @@
     <Page Include="OptionsPage.xaml" />
     <Page Include="Dialogs.xaml" />
   </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
 </Project>

--- a/samples/LoginCpp/LoginCpp/LoginCpp.WindowsPhone/packages.config
+++ b/samples/LoginCpp/LoginCpp/LoginCpp.WindowsPhone/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="FBWinSDK" version="0.9.0" targetFramework="Native" />
-</packages>

--- a/samples/LoginCs/LoginCs.sln
+++ b/samples/LoginCs/LoginCs.sln
@@ -11,17 +11,16 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LoginCs.Windows", "LoginCs\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LoginCs.WindowsPhone", "LoginCs\LoginCs.WindowsPhone\LoginCs.WindowsPhone.csproj", "{EF5F7E3E-8E45-4027-846C-3349247C065D}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{3171A043-57BD-4AEE-95F8-56CD3749B615}"
-	ProjectSection(SolutionItems) = preProject
-		.nuget\NuGet.Config = .nuget\NuGet.Config
-		.nuget\NuGet.exe = .nuget\NuGet.exe
-		.nuget\NuGet.targets = .nuget\NuGet.targets
-	EndProjectSection
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "FBWinSDK.Windows", "..\..\FBWinSDK\FBWinSDK\FBWinSDK.Windows\FBWinSDK.Windows.vcxproj", "{418FC79B-AA0F-4951-A7D9-7DA89BDF8FB6}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "FBWinSDK.WindowsPhone", "..\..\FBWinSDK\FBWinSDK\FBWinSDK.WindowsPhone\FBWinSDK.WindowsPhone.vcxproj", "{F833B1E6-2866-4A47-89E2-C474983FE70F}"
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		..\..\FBWinSDK\FBWinSDK\FBWinSDK.Shared\FBWinSDK.Shared.vcxitems*{418fc79b-aa0f-4951-a7d9-7da89bdf8fb6}*SharedItemsImports = 4
 		LoginCs\LoginCs.Shared\LoginCs.Shared.projitems*{a506e326-7a59-479e-8e80-65fb73ae94d8}*SharedItemsImports = 4
 		LoginCs\LoginCs.Shared\LoginCs.Shared.projitems*{5364ddc1-f2ca-4959-9292-546c26254cd2}*SharedItemsImports = 13
+		..\..\FBWinSDK\FBWinSDK\FBWinSDK.Shared\FBWinSDK.Shared.vcxitems*{f833b1e6-2866-4a47-89e2-c474983fe70f}*SharedItemsImports = 4
 		LoginCs\LoginCs.Shared\LoginCs.Shared.projitems*{ef5f7e3e-8e45-4027-846c-3349247c065d}*SharedItemsImports = 4
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -71,6 +70,32 @@ Global
 		{EF5F7E3E-8E45-4027-846C-3349247C065D}.Release|x86.ActiveCfg = Release|x86
 		{EF5F7E3E-8E45-4027-846C-3349247C065D}.Release|x86.Build.0 = Release|x86
 		{EF5F7E3E-8E45-4027-846C-3349247C065D}.Release|x86.Deploy.0 = Release|x86
+		{418FC79B-AA0F-4951-A7D9-7DA89BDF8FB6}.Debug|Any CPU.ActiveCfg = Debug|Win32
+		{418FC79B-AA0F-4951-A7D9-7DA89BDF8FB6}.Debug|ARM.ActiveCfg = Debug|ARM
+		{418FC79B-AA0F-4951-A7D9-7DA89BDF8FB6}.Debug|ARM.Build.0 = Debug|ARM
+		{418FC79B-AA0F-4951-A7D9-7DA89BDF8FB6}.Debug|x64.ActiveCfg = Debug|x64
+		{418FC79B-AA0F-4951-A7D9-7DA89BDF8FB6}.Debug|x64.Build.0 = Debug|x64
+		{418FC79B-AA0F-4951-A7D9-7DA89BDF8FB6}.Debug|x86.ActiveCfg = Debug|Win32
+		{418FC79B-AA0F-4951-A7D9-7DA89BDF8FB6}.Debug|x86.Build.0 = Debug|Win32
+		{418FC79B-AA0F-4951-A7D9-7DA89BDF8FB6}.Release|Any CPU.ActiveCfg = Release|Win32
+		{418FC79B-AA0F-4951-A7D9-7DA89BDF8FB6}.Release|ARM.ActiveCfg = Release|ARM
+		{418FC79B-AA0F-4951-A7D9-7DA89BDF8FB6}.Release|ARM.Build.0 = Release|ARM
+		{418FC79B-AA0F-4951-A7D9-7DA89BDF8FB6}.Release|x64.ActiveCfg = Release|x64
+		{418FC79B-AA0F-4951-A7D9-7DA89BDF8FB6}.Release|x64.Build.0 = Release|x64
+		{418FC79B-AA0F-4951-A7D9-7DA89BDF8FB6}.Release|x86.ActiveCfg = Release|Win32
+		{418FC79B-AA0F-4951-A7D9-7DA89BDF8FB6}.Release|x86.Build.0 = Release|Win32
+		{F833B1E6-2866-4A47-89E2-C474983FE70F}.Debug|Any CPU.ActiveCfg = Debug|Win32
+		{F833B1E6-2866-4A47-89E2-C474983FE70F}.Debug|ARM.ActiveCfg = Debug|ARM
+		{F833B1E6-2866-4A47-89E2-C474983FE70F}.Debug|ARM.Build.0 = Debug|ARM
+		{F833B1E6-2866-4A47-89E2-C474983FE70F}.Debug|x64.ActiveCfg = Debug|Win32
+		{F833B1E6-2866-4A47-89E2-C474983FE70F}.Debug|x86.ActiveCfg = Debug|Win32
+		{F833B1E6-2866-4A47-89E2-C474983FE70F}.Debug|x86.Build.0 = Debug|Win32
+		{F833B1E6-2866-4A47-89E2-C474983FE70F}.Release|Any CPU.ActiveCfg = Release|Win32
+		{F833B1E6-2866-4A47-89E2-C474983FE70F}.Release|ARM.ActiveCfg = Release|ARM
+		{F833B1E6-2866-4A47-89E2-C474983FE70F}.Release|ARM.Build.0 = Release|ARM
+		{F833B1E6-2866-4A47-89E2-C474983FE70F}.Release|x64.ActiveCfg = Release|Win32
+		{F833B1E6-2866-4A47-89E2-C474983FE70F}.Release|x86.ActiveCfg = Release|Win32
+		{F833B1E6-2866-4A47-89E2-C474983FE70F}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/samples/LoginCs/LoginCs/LoginCs.Shared/App.xaml.cs
+++ b/samples/LoginCs/LoginCs/LoginCs.Shared/App.xaml.cs
@@ -60,33 +60,6 @@ namespace LoginCs
             this.Suspending += this.OnSuspending;
         }
 
-#if WINDOWS_PHONE_APP
-        protected override void OnActivated(IActivatedEventArgs args)
-        {
-            if (args.Kind == ActivationKind.Protocol)
-            {
-                HandleProtocolActivation(args);
-            }
-        }
-
-        async void HandleProtocolActivation(IActivatedEventArgs args)
-        {
-            ProtocolActivatedEventArgs pArgs = 
-                (ProtocolActivatedEventArgs)args;
-            FBSession sess = FBSession.ActiveSession;
-
-            FBResult result = await sess.ContinueAction(pArgs);
-            if (result.Succeeded)
-            {
-                await Window.Current.Dispatcher.RunAsync(
-                    Windows.UI.Core.CoreDispatcherPriority.Normal,
-                () =>
-                {
-                    RootFrame.Navigate(typeof(UserInfo));
-                });
-            }
-        }
-#endif
         const string FBAppIDName      = "FBApplicationId";
         const string FBPhoneAppIDName = "FBWinPhoneAppId";
         const string FBStoreAppIDName = "FBWinStoreAppId";

--- a/samples/LoginCs/LoginCs/LoginCs.Windows/LoginCs.Windows.csproj
+++ b/samples/LoginCs/LoginCs/LoginCs.Windows/LoginCs.Windows.csproj
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\FBWinSDK.0.9.0\build\win\FBWinSDK.props" Condition="Exists('..\..\packages\FBWinSDK.0.9.0\build\win\FBWinSDK.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -152,31 +151,25 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Facebook">
-      <HintPath>..\..\packages\FBWinSDK.0.9.0\lib\win\Facebook.winmd</HintPath>
-    </Reference>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\netcore45\Newtonsoft.Json.dll</HintPath>
+    <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.7.0.1\lib\portable-net40+sl5+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
+    <ProjectReference Include="..\..\..\..\FBWinSDK\FBWinSDK\FBWinSDK.Windows\FBWinSDK.Windows.vcxproj">
+      <Project>{418fc79b-aa0f-4951-a7d9-7da89bdf8fb6}</Project>
+      <Name>FBWinSDK.Windows</Name>
+    </ProjectReference>
   </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '12.0' ">
     <VisualStudioVersion>12.0</VisualStudioVersion>
   </PropertyGroup>
   <Import Project="..\LoginCs.Shared\LoginCs.Shared.projitems" Label="Shared" />
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\FBWinSDK.0.9.0\build\win\FBWinSDK.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\FBWinSDK.0.9.0\build\win\FBWinSDK.props'))" />
-    <Error Condition="!Exists('..\..\packages\FBWinSDK.0.9.0\build\win\FBWinSDK.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\FBWinSDK.0.9.0\build\win\FBWinSDK.targets'))" />
-    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
-  </Target>
-  <Import Project="..\..\packages\FBWinSDK.0.9.0\build\win\FBWinSDK.targets" Condition="Exists('..\..\packages\FBWinSDK.0.9.0\build\win\FBWinSDK.targets')" />
-  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/samples/LoginCs/LoginCs/LoginCs.Windows/MainPage.xaml.cs
+++ b/samples/LoginCs/LoginCs/LoginCs.Windows/MainPage.xaml.cs
@@ -96,13 +96,13 @@ namespace LoginCs
             }
         }
 
-        private void login_OnClicked(object sender, RoutedEventArgs e)
+        private async void login_OnClicked(object sender, RoutedEventArgs e)
         {
             FBSession sess = FBSession.ActiveSession;
             if (sess.LoggedIn)
             {
                 LoginButton.Content = "Login";
-                sess.Logout();
+                await sess.Logout();
                 //Navigate back to same page, to clear out logged in info.
                 App.RootFrame.Navigate(typeof(MainPage));
             }

--- a/samples/LoginCs/LoginCs/LoginCs.Windows/packages.config
+++ b/samples/LoginCs/LoginCs/LoginCs.Windows/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FBWinSDK" version="0.9.0" targetFramework="win81" />
-  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="win81" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="win81" userInstalled="true" />
 </packages>

--- a/samples/LoginCs/LoginCs/LoginCs.WindowsPhone/LoginCs.WindowsPhone.csproj
+++ b/samples/LoginCs/LoginCs/LoginCs.WindowsPhone/LoginCs.WindowsPhone.csproj
@@ -117,14 +117,6 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Facebook">
-      <HintPath>..\..\packages\FBWinSDK.0.9.0\lib\wpa\Facebook.winmd</HintPath>
-    </Reference>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\portable-net40+sl5+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-  <ItemGroup>
     <None Include="..\LoginCs.Shared\FBCSObjectImplementation.ttinclude">
       <Link>FBCSObjectImplementation.ttinclude</Link>
     </None>

--- a/samples/LoginCs/LoginCs/LoginCs.WindowsPhone/LoginCs.WindowsPhone.csproj
+++ b/samples/LoginCs/LoginCs/LoginCs.WindowsPhone/LoginCs.WindowsPhone.csproj
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\FBWinSDK.0.9.0\build\wpa\FBWinSDK.props" Condition="Exists('..\..\packages\FBWinSDK.0.9.0\build\wpa\FBWinSDK.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -142,6 +141,18 @@
   <ItemGroup>
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
   </ItemGroup>
+  <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.7.0.1\lib\portable-net40+sl5+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\FBWinSDK\FBWinSDK\FBWinSDK.WindowsPhone\FBWinSDK.WindowsPhone.vcxproj">
+      <Project>{f833b1e6-2866-4a47-89e2-c474983fe70f}</Project>
+      <Name>FBWinSDK.WindowsPhone</Name>
+    </ProjectReference>
+  </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '12.0' ">
     <VisualStudioVersion>12.0</VisualStudioVersion>
   </PropertyGroup>
@@ -150,16 +161,6 @@
   </PropertyGroup>
   <Import Project="..\LoginCs.Shared\LoginCs.Shared.projitems" Label="Shared" />
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\FBWinSDK.0.9.0\build\wpa\FBWinSDK.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\FBWinSDK.0.9.0\build\wpa\FBWinSDK.props'))" />
-    <Error Condition="!Exists('..\..\packages\FBWinSDK.0.9.0\build\wpa\FBWinSDK.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\FBWinSDK.0.9.0\build\wpa\FBWinSDK.targets'))" />
-    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
-  </Target>
-  <Import Project="..\..\packages\FBWinSDK.0.9.0\build\wpa\FBWinSDK.targets" Condition="Exists('..\..\packages\FBWinSDK.0.9.0\build\wpa\FBWinSDK.targets')" />
-  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/samples/LoginCs/LoginCs/LoginCs.WindowsPhone/MainPage.xaml.cs
+++ b/samples/LoginCs/LoginCs/LoginCs.WindowsPhone/MainPage.xaml.cs
@@ -75,7 +75,7 @@ namespace LoginCs
 
             // Launches a URI to redirect to the FB app, which will log us in
             // and return the result via our registered protocol.
-            await s.LoginAndContinue();
+            FBResult result = await s.LoginAsync();
         }
 
         /// <summary>
@@ -110,13 +110,13 @@ namespace LoginCs
             }
         }
 
-        private void login_OnClicked(object sender, RoutedEventArgs e)
+        private async void login_OnClicked(object sender, RoutedEventArgs e)
         {
             FBSession sess = FBSession.ActiveSession;
             if (sess.LoggedIn)
             {
                 LoginButton.Content = "Login";
-                sess.Logout();
+                await sess.Logout();
                 //Navigate back to same page, to clear out logged in info.
                 App.RootFrame.Navigate(typeof(MainPage));
             }

--- a/samples/LoginCs/LoginCs/LoginCs.WindowsPhone/Package.appxmanifest
+++ b/samples/LoginCs/LoginCs/LoginCs.WindowsPhone/Package.appxmanifest
@@ -21,11 +21,6 @@
         </m3:DefaultTile>
         <m3:SplashScreen Image="Assets\SplashScreen.png" />
       </m3:VisualElements>
-      <Extensions>
-        <Extension Category="windows.protocol">
-          <Protocol Name="fb1406183856361054" />
-        </Extension>
-      </Extensions>
     </Application>
   </Applications>
   <Capabilities>

--- a/samples/LoginCs/LoginCs/LoginCs.WindowsPhone/packages.config
+++ b/samples/LoginCs/LoginCs/LoginCs.WindowsPhone/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FBWinSDK" version="0.9.0" targetFramework="wpa81" />
-  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="wpa81" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="wpa81" userInstalled="true" />
 </packages>


### PR DESCRIPTION
Had to also make some code changes to LoginCs project, but mostly this is just changing the way the samples refer to the SDK.  Samples all run properly again with the new setup.