### PR TITLE
TryOpenSession method

### DIFF
--- a/FBWinSDK/FBWinSDK/FBWinSDK.Shared/FacebookSession.h
+++ b/FBWinSDK/FBWinSDK/FBWinSDK.Shared/FacebookSession.h
@@ -132,6 +132,9 @@ namespace Facebook
                 SessionLoginBehavior behavior
                 );
 
+            //! Try open session with existing token without appear login interface
+            Windows::Foundation::IAsyncOperation<FBResult^>^ TryOpenSession();
+
             void SetAPIVersion(
                 int MajorVersion,
                 int MinorVersion


### PR DESCRIPTION
In this pull request added method for open existing session, saved in SDK file. Used in store application right now - we can use FB information, if user already logged in, without "TryLoginAsync" and login interface appear 