### PR TITLE
Fix when using Facebook Menu to log out in a FeedDialog #103 (Tip N°2)

### DIFF
--- a/samples/LoginCpp-UWP/LoginCpp/Dialogs.xaml.cpp
+++ b/samples/LoginCpp-UWP/LoginCpp/Dialogs.xaml.cpp
@@ -137,16 +137,24 @@ void Dialogs::Feed_Click(
     )
 {
     FBSession^ s = FBSession::ActiveSession;
-    PropertySet^ params = ref new PropertySet();
-    params->Insert(L"caption", L"I love Brussels Sprouts!");
-    params->Insert(L"link", L"https://en.wikipedia.org/wiki/Brussels_sprout");
-    params->Insert(L"description", L"Om Nom Nom!");
 
-    create_task(s->ShowFeedDialogAsync(params))
-        .then([=](FBResult^ DialogResponse)
-    {
-        OutputDebugString(L"Showed 'Feed' dialog.\n");
-    });
+	if (s->AccessTokenData == nullptr)
+	{
+		OutputDebugString(L"User is not logged (access token was deleted).\n");
+	}
+	else
+	{
+		PropertySet^ params = ref new PropertySet();
+		params->Insert(L"caption", L"I love Brussels Sprouts!");
+		params->Insert(L"link", L"https://en.wikipedia.org/wiki/Brussels_sprout");
+		params->Insert(L"description", L"Om Nom Nom!");
+
+		create_task(s->ShowFeedDialogAsync(params))
+			.then([=](FBResult^ DialogResponse)
+		{
+			OutputDebugString(L"Showed 'Feed' dialog.\n");
+		});
+	}
 }
 
 
@@ -156,14 +164,22 @@ void Dialogs::AppRequests_Click(
     )
 {
     FBSession^ s = FBSession::ActiveSession;
-    PropertySet^ params = ref new PropertySet();
 
-    params->Insert(L"title", L"I love Brussels Sprouts!");
-    params->Insert(L"message", L"Om Nom Nom!");
+	if (s->AccessTokenData == nullptr)
+	{
+		OutputDebugString(L"User is not logged (access token was deleted).\n");
+	}
+	else
+	{
+		PropertySet^ params = ref new PropertySet();
 
-    create_task(s->ShowRequestsDialogAsync(params))
-        .then([=](FBResult^ DialogResponse)
-    {
-        OutputDebugString(L"Showed 'Requests' dialog.\n");
-    });
+		params->Insert(L"title", L"I love Brussels Sprouts!");
+		params->Insert(L"message", L"Om Nom Nom!");
+
+		create_task(s->ShowRequestsDialogAsync(params))
+			.then([=](FBResult^ DialogResponse)
+		{
+			OutputDebugString(L"Showed 'Requests' dialog.\n");
+		});
+	}
 }

--- a/samples/LoginCpp-UWP/LoginCpp/Dialogs.xaml.cpp
+++ b/samples/LoginCpp-UWP/LoginCpp/Dialogs.xaml.cpp
@@ -44,29 +44,29 @@ using namespace Windows::UI::Xaml::Navigation;
 
 Dialogs::Dialogs()
 {
-	InitializeComponent();
-	SetValue(_defaultViewModelProperty, ref new Platform::Collections::Map<String^, Object^>(std::less<String^>()));
-	auto navigationHelper = ref new Common::NavigationHelper(this);
-	SetValue(_navigationHelperProperty, navigationHelper);
-	navigationHelper->LoadState += ref new Common::LoadStateEventHandler(this, &Dialogs::LoadState);
-	navigationHelper->SaveState += ref new Common::SaveStateEventHandler(this, &Dialogs::SaveState);
+    InitializeComponent();
+    SetValue(_defaultViewModelProperty, ref new Platform::Collections::Map<String^, Object^>(std::less<String^>()));
+    auto navigationHelper = ref new Common::NavigationHelper(this);
+    SetValue(_navigationHelperProperty, navigationHelper);
+    navigationHelper->LoadState += ref new Common::LoadStateEventHandler(this, &Dialogs::LoadState);
+    navigationHelper->SaveState += ref new Common::SaveStateEventHandler(this, &Dialogs::SaveState);
 }
 
 DependencyProperty^ Dialogs::_defaultViewModelProperty =
 DependencyProperty::Register("DefaultViewModel",
-TypeName(IObservableMap<String^, Object^>::typeid), TypeName(Dialogs::typeid), nullptr);
+    TypeName(IObservableMap<String^, Object^>::typeid), TypeName(Dialogs::typeid), nullptr);
 
 /// <summary>
 /// Used as a trivial view model.
 /// </summary>
 IObservableMap<String^, Object^>^ Dialogs::DefaultViewModel::get()
 {
-	return safe_cast<IObservableMap<String^, Object^>^>(GetValue(_defaultViewModelProperty));
+    return safe_cast<IObservableMap<String^, Object^>^>(GetValue(_defaultViewModelProperty));
 }
 
 DependencyProperty^ Dialogs::_navigationHelperProperty =
 DependencyProperty::Register("NavigationHelper",
-TypeName(Common::NavigationHelper::typeid), TypeName(Dialogs::typeid), nullptr);
+    TypeName(Common::NavigationHelper::typeid), TypeName(Dialogs::typeid), nullptr);
 
 /// <summary>
 /// Gets an implementation of <see cref="NavigationHelper"/> designed to be
@@ -74,7 +74,7 @@ TypeName(Common::NavigationHelper::typeid), TypeName(Dialogs::typeid), nullptr);
 /// </summary>
 Common::NavigationHelper^ Dialogs::NavigationHelper::get()
 {
-	return safe_cast<Common::NavigationHelper^>(GetValue(_navigationHelperProperty));
+    return safe_cast<Common::NavigationHelper^>(GetValue(_navigationHelperProperty));
 }
 
 #pragma region Navigation support
@@ -90,12 +90,12 @@ Common::NavigationHelper^ Dialogs::NavigationHelper::get()
 
 void Dialogs::OnNavigatedTo(NavigationEventArgs^ e)
 {
-	NavigationHelper->OnNavigatedTo(e);
+    NavigationHelper->OnNavigatedTo(e);
 }
 
 void Dialogs::OnNavigatedFrom(NavigationEventArgs^ e)
 {
-	NavigationHelper->OnNavigatedFrom(e);
+    NavigationHelper->OnNavigatedFrom(e);
 }
 
 #pragma endregion
@@ -113,8 +113,8 @@ void Dialogs::OnNavigatedFrom(NavigationEventArgs^ e)
 /// session. The state will be null the first time a page is visited.</param>
 void Dialogs::LoadState(Object^ sender, Common::LoadStateEventArgs^ e)
 {
-	(void) sender;	// Unused parameter
-	(void) e;	// Unused parameter
+    (void)sender;   // Unused parameter
+    (void)e;        // Unused parameter
 }
 
 /// <summary>
@@ -125,61 +125,61 @@ void Dialogs::LoadState(Object^ sender, Common::LoadStateEventArgs^ e)
 /// <param name="sender">The source of the event; typically <see cref="NavigationHelper"/></param>
 /// <param name="e">Event data that provides an empty dictionary to be populated with
 /// serializable state.</param>
-void Dialogs::SaveState(Object^ sender, Common::SaveStateEventArgs^ e){
-	(void) sender;	// Unused parameter
-	(void) e; // Unused parameter
+void Dialogs::SaveState(Object^ sender, Common::SaveStateEventArgs^ e) {
+    (void)sender;   // Unused parameter
+    (void)e;        // Unused parameter
 }
 
 
 void Dialogs::Feed_Click(
-    Object^ sender, 
+    Object^ sender,
     RoutedEventArgs^ e
     )
 {
     FBSession^ s = FBSession::ActiveSession;
 
-	if (s->AccessTokenData == nullptr)
-	{
-		OutputDebugString(L"User is not logged (access token was deleted).\n");
-	}
-	else
-	{
-		PropertySet^ params = ref new PropertySet();
-		params->Insert(L"caption", L"I love Brussels Sprouts!");
-		params->Insert(L"link", L"https://en.wikipedia.org/wiki/Brussels_sprout");
-		params->Insert(L"description", L"Om Nom Nom!");
+    if (!s->LoggedIn)
+    {
+        OutputDebugString(L"The user is no longer logged in.\n");
+    }
+    else
+    {
+        PropertySet^ params = ref new PropertySet();
+        params->Insert(L"caption", L"I love Brussels Sprouts!");
+        params->Insert(L"link", L"https://en.wikipedia.org/wiki/Brussels_sprout");
+        params->Insert(L"description", L"Om Nom Nom!");
 
-		create_task(s->ShowFeedDialogAsync(params))
-			.then([=](FBResult^ DialogResponse)
-		{
-			OutputDebugString(L"Showed 'Feed' dialog.\n");
-		});
-	}
+        create_task(s->ShowFeedDialogAsync(params))
+            .then([=](FBResult^ DialogResponse)
+        {
+            OutputDebugString(L"Showed 'Feed' dialog.\n");
+        });
+    }
 }
 
 
 void Dialogs::AppRequests_Click(
-    Object^ sender, 
+    Object^ sender,
     RoutedEventArgs^ e
     )
 {
     FBSession^ s = FBSession::ActiveSession;
 
-	if (s->AccessTokenData == nullptr)
-	{
-		OutputDebugString(L"User is not logged (access token was deleted).\n");
-	}
-	else
-	{
-		PropertySet^ params = ref new PropertySet();
+    if (!s->LoggedIn)
+    {
+        OutputDebugString(L"The user is no longer logged in.\n");
+    }
+    else
+    {
+        PropertySet^ params = ref new PropertySet();
 
-		params->Insert(L"title", L"I love Brussels Sprouts!");
-		params->Insert(L"message", L"Om Nom Nom!");
+        params->Insert(L"title", L"I love Brussels Sprouts!");
+        params->Insert(L"message", L"Om Nom Nom!");
 
-		create_task(s->ShowRequestsDialogAsync(params))
-			.then([=](FBResult^ DialogResponse)
-		{
-			OutputDebugString(L"Showed 'Requests' dialog.\n");
-		});
-	}
+        create_task(s->ShowRequestsDialogAsync(params))
+            .then([=](FBResult^ DialogResponse)
+        {
+            OutputDebugString(L"Showed 'Requests' dialog.\n");
+        });
+    }
 }

--- a/samples/LoginCpp/LoginCpp/LoginCpp.Windows/Dialogs.xaml.cpp
+++ b/samples/LoginCpp/LoginCpp/LoginCpp.Windows/Dialogs.xaml.cpp
@@ -41,37 +41,53 @@ using namespace Windows::UI::Xaml::Navigation;
 
 Dialogs::Dialogs()
 {
-	InitializeComponent();
+    InitializeComponent();
 }
 
 
 void LoginCpp::Dialogs::FeedDialogButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
 {
     FBSession^ s = FBSession::ActiveSession;
-    PropertySet^ params = ref new PropertySet();
-    params->Insert(L"caption", L"I love Brussels Sprouts!");
-    params->Insert(L"link", L"https://en.wikipedia.org/wiki/Brussels_sprout");
-    params->Insert(L"description", L"Om Nom Nom!");
 
-    create_task(s->ShowFeedDialogAsync(params))
-        .then([=](FBResult^ Response)
+    if (!s->LoggedIn)
     {
-        OutputDebugString(L"Showed 'Feed' dialog.\n");
-    });
+        OutputDebugString(L"The user is no longer logged in.\n");
+    }
+    else
+    {
+        PropertySet^ params = ref new PropertySet();
+        params->Insert(L"caption", L"I love Brussels Sprouts!");
+        params->Insert(L"link", L"https://en.wikipedia.org/wiki/Brussels_sprout");
+        params->Insert(L"description", L"Om Nom Nom!");
+
+        create_task(s->ShowFeedDialogAsync(params))
+            .then([=](FBResult^ Response)
+        {
+            OutputDebugString(L"Showed 'Feed' dialog.\n");
+        });
+    }
 }
 
 
 void LoginCpp::Dialogs::AppRequestsButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
 {
     FBSession^ s = FBSession::ActiveSession;
-    PropertySet^ params = ref new PropertySet();
 
-    params->Insert(L"title", L"I love Brussels Sprouts!");
-    params->Insert(L"message", L"Om Nom Nom!");
-
-    create_task(s->ShowRequestsDialogAsync(params))
-        .then([=](FBResult^ Response)
+    if (!s->LoggedIn)
     {
-        OutputDebugString(L"Showed 'Requests' dialog.\n");
-    });
+        OutputDebugString(L"The user is no longer logged in.\n");
+    }
+    else
+    {
+        PropertySet^ params = ref new PropertySet();
+
+        params->Insert(L"title", L"I love Brussels Sprouts!");
+        params->Insert(L"message", L"Om Nom Nom!");
+
+        create_task(s->ShowRequestsDialogAsync(params))
+            .then([=](FBResult^ Response)
+        {
+            OutputDebugString(L"Showed 'Requests' dialog.\n");
+        });
+    }
 }

--- a/samples/LoginCpp/LoginCpp/LoginCpp.WindowsPhone/Dialogs.xaml.cpp
+++ b/samples/LoginCpp/LoginCpp/LoginCpp.WindowsPhone/Dialogs.xaml.cpp
@@ -44,29 +44,29 @@ using namespace Windows::UI::Xaml::Navigation;
 
 Dialogs::Dialogs()
 {
-	InitializeComponent();
-	SetValue(_defaultViewModelProperty, ref new Platform::Collections::Map<String^, Object^>(std::less<String^>()));
-	auto navigationHelper = ref new Common::NavigationHelper(this);
-	SetValue(_navigationHelperProperty, navigationHelper);
-	navigationHelper->LoadState += ref new Common::LoadStateEventHandler(this, &Dialogs::LoadState);
-	navigationHelper->SaveState += ref new Common::SaveStateEventHandler(this, &Dialogs::SaveState);
+    InitializeComponent();
+    SetValue(_defaultViewModelProperty, ref new Platform::Collections::Map<String^, Object^>(std::less<String^>()));
+    auto navigationHelper = ref new Common::NavigationHelper(this);
+    SetValue(_navigationHelperProperty, navigationHelper);
+    navigationHelper->LoadState += ref new Common::LoadStateEventHandler(this, &Dialogs::LoadState);
+    navigationHelper->SaveState += ref new Common::SaveStateEventHandler(this, &Dialogs::SaveState);
 }
 
 DependencyProperty^ Dialogs::_defaultViewModelProperty =
 DependencyProperty::Register("DefaultViewModel",
-TypeName(IObservableMap<String^, Object^>::typeid), TypeName(Dialogs::typeid), nullptr);
+    TypeName(IObservableMap<String^, Object^>::typeid), TypeName(Dialogs::typeid), nullptr);
 
 /// <summary>
 /// Used as a trivial view model.
 /// </summary>
 IObservableMap<String^, Object^>^ Dialogs::DefaultViewModel::get()
 {
-	return safe_cast<IObservableMap<String^, Object^>^>(GetValue(_defaultViewModelProperty));
+    return safe_cast<IObservableMap<String^, Object^>^>(GetValue(_defaultViewModelProperty));
 }
 
 DependencyProperty^ Dialogs::_navigationHelperProperty =
 DependencyProperty::Register("NavigationHelper",
-TypeName(Common::NavigationHelper::typeid), TypeName(Dialogs::typeid), nullptr);
+    TypeName(Common::NavigationHelper::typeid), TypeName(Dialogs::typeid), nullptr);
 
 /// <summary>
 /// Gets an implementation of <see cref="NavigationHelper"/> designed to be
@@ -74,7 +74,7 @@ TypeName(Common::NavigationHelper::typeid), TypeName(Dialogs::typeid), nullptr);
 /// </summary>
 Common::NavigationHelper^ Dialogs::NavigationHelper::get()
 {
-	return safe_cast<Common::NavigationHelper^>(GetValue(_navigationHelperProperty));
+    return safe_cast<Common::NavigationHelper^>(GetValue(_navigationHelperProperty));
 }
 
 #pragma region Navigation support
@@ -90,12 +90,12 @@ Common::NavigationHelper^ Dialogs::NavigationHelper::get()
 
 void Dialogs::OnNavigatedTo(NavigationEventArgs^ e)
 {
-	NavigationHelper->OnNavigatedTo(e);
+    NavigationHelper->OnNavigatedTo(e);
 }
 
 void Dialogs::OnNavigatedFrom(NavigationEventArgs^ e)
 {
-	NavigationHelper->OnNavigatedFrom(e);
+    NavigationHelper->OnNavigatedFrom(e);
 }
 
 #pragma endregion
@@ -113,8 +113,8 @@ void Dialogs::OnNavigatedFrom(NavigationEventArgs^ e)
 /// session. The state will be null the first time a page is visited.</param>
 void Dialogs::LoadState(Object^ sender, Common::LoadStateEventArgs^ e)
 {
-	(void) sender;	// Unused parameter
-	(void) e;	// Unused parameter
+    (void)sender;   // Unused parameter
+    (void)e;        // Unused parameter
 }
 
 /// <summary>
@@ -125,45 +125,60 @@ void Dialogs::LoadState(Object^ sender, Common::LoadStateEventArgs^ e)
 /// <param name="sender">The source of the event; typically <see cref="NavigationHelper"/></param>
 /// <param name="e">Event data that provides an empty dictionary to be populated with
 /// serializable state.</param>
-void Dialogs::SaveState(Object^ sender, Common::SaveStateEventArgs^ e){
-	(void) sender;	// Unused parameter
-	(void) e; // Unused parameter
+void Dialogs::SaveState(Object^ sender, Common::SaveStateEventArgs^ e) {
+    (void)sender;   // Unused parameter
+    (void)e;        // Unused parameter
 }
 
 
 void Dialogs::Feed_Click(
-    Object^ sender, 
+    Object^ sender,
     RoutedEventArgs^ e
     )
 {
     FBSession^ s = FBSession::ActiveSession;
-    PropertySet^ params = ref new PropertySet();
-    params->Insert(L"caption", L"I love Brussels Sprouts!");
-    params->Insert(L"link", L"https://en.wikipedia.org/wiki/Brussels_sprout");
-    params->Insert(L"description", L"Om Nom Nom!");
-
-    create_task(s->ShowFeedDialogAsync(params))
-        .then([=](FBResult^ Response)
+    if (!s->LoggedIn)
     {
-        OutputDebugString(L"Showed 'Feed' dialog.\n");
-    });
+        OutputDebugString(L"The user is no longer logged in.\n");
+    }
+    else
+    {
+        PropertySet^ params = ref new PropertySet();
+        params->Insert(L"caption", L"I love Brussels Sprouts!");
+        params->Insert(L"link", L"https://en.wikipedia.org/wiki/Brussels_sprout");
+        params->Insert(L"description", L"Om Nom Nom!");
+
+        create_task(s->ShowFeedDialogAsync(params))
+            .then([=](FBResult^ Response)
+        {
+            OutputDebugString(L"Showed 'Feed' dialog.\n");
+        });
+    }
 }
 
 
 void Dialogs::AppRequests_Click(
-    Object^ sender, 
+    Object^ sender,
     RoutedEventArgs^ e
     )
 {
     FBSession^ s = FBSession::ActiveSession;
-    PropertySet^ params = ref new PropertySet();
 
-    params->Insert(L"title", L"I love Brussels Sprouts!");
-    params->Insert(L"message", L"Om Nom Nom!");
-
-    create_task(s->ShowRequestsDialogAsync(params))
-        .then([=](FBResult^ Response)
+    if (!s->LoggedIn)
     {
-        OutputDebugString(L"Showed 'Requests' dialog.\n");
-    });
+        OutputDebugString(L"The user is no longer logged in.\n");
+    }
+    else
+    {
+        PropertySet^ params = ref new PropertySet();
+
+        params->Insert(L"title", L"I love Brussels Sprouts!");
+        params->Insert(L"message", L"Om Nom Nom!");
+
+        create_task(s->ShowRequestsDialogAsync(params))
+            .then([=](FBResult^ Response)
+        {
+            OutputDebugString(L"Showed 'Requests' dialog.\n");
+        });
+    }
 }

--- a/winsdkfb/winsdkfb/winsdkfb.Shared/FacebookDialog.xaml.cpp
+++ b/winsdkfb/winsdkfb/winsdkfb.Shared/FacebookDialog.xaml.cpp
@@ -55,6 +55,7 @@ using namespace std;
 #define FACEBOOK_DESKTOP_SERVER_NAME L"www"
 #define FACEBOOK_MOBILE_SERVER_NAME  L"m"
 #define FACEBOOK_LOGIN_SUCCESS_PATH  L"/connect/login_success.html"
+#define FACEBOOK_LOGOUT_PATH  L"/logout.php"
 #define FACEBOOK_DIALOG_CLOSE_PATH   L"/dialog/close"
 
 const wchar_t* ErrorObjectJson = L"{\"error\": {\"message\": " \
@@ -399,6 +400,13 @@ bool FacebookDialog::IsLoginSuccessRedirect(
     return (String::CompareOrdinal(Response->Path, FACEBOOK_LOGIN_SUCCESS_PATH) == 0);
 }
 
+bool FacebookDialog::IsLogoutRedirect(
+	Uri^ Response
+	)
+{
+	return (String::CompareOrdinal(Response->Path, FACEBOOK_LOGOUT_PATH) == 0);
+}
+
 bool FacebookDialog::IsDialogCloseRedirect(
     Uri^ Response
     )
@@ -463,6 +471,17 @@ void FacebookDialog::dialogWebView_FeedNavStarting(
             _dialogResponse = ref new FBResult(err);
         }
     }
+	else if (IsLogoutRedirect(e->Uri))
+	{
+		UninitDialog();
+
+		DebugPrintLine(L"Feed response is " + e->Uri->DisplayUri);
+		FBSession^ sess = FBSession::ActiveSession;
+		sess->LogoutAsync();
+
+		FBError^ err = FBError::FromJson(ref new String(ErrorObjectJson));
+		_dialogResponse = ref new FBResult(err);
+	}
     else if (IsDialogCloseRedirect(e->Uri))
     {
         UninitDialog();

--- a/winsdkfb/winsdkfb/winsdkfb.Shared/FacebookDialog.xaml.cpp
+++ b/winsdkfb/winsdkfb/winsdkfb.Shared/FacebookDialog.xaml.cpp
@@ -64,6 +64,11 @@ L"\"OAuthException\", \"code\": 4201, " \
 L"\"error_user_msg\": \"User canceled the Dialog flow\"" \
 L"}}";
 
+const wchar_t* ErrorObjectJsonLogout = L"{\"error\": {\"message\": " \
+L"\"Operation Canceled\", \"type\": " \
+L"\"OAuthException\", \"code\": 4202, " \
+L"\"error_user_msg\": \"User logged out\"" \
+L"}}";
 
 #ifdef _DEBUG
 void DebugPrintLine(
@@ -401,10 +406,10 @@ bool FacebookDialog::IsLoginSuccessRedirect(
 }
 
 bool FacebookDialog::IsLogoutRedirect(
-	Uri^ Response
-	)
+    Uri^ Response
+    )
 {
-	return (String::CompareOrdinal(Response->Path, FACEBOOK_LOGOUT_PATH) == 0);
+    return (String::CompareOrdinal(Response->Path, FACEBOOK_LOGOUT_PATH) == 0);
 }
 
 bool FacebookDialog::IsDialogCloseRedirect(
@@ -471,17 +476,17 @@ void FacebookDialog::dialogWebView_FeedNavStarting(
             _dialogResponse = ref new FBResult(err);
         }
     }
-	else if (IsLogoutRedirect(e->Uri))
-	{
-		UninitDialog();
+    else if (IsLogoutRedirect(e->Uri))
+    {
+        UninitDialog();
 
-		DebugPrintLine(L"Feed response is " + e->Uri->DisplayUri);
-		FBSession^ sess = FBSession::ActiveSession;
-		sess->LogoutAsync();
+        DebugPrintLine(L"Feed response is " + e->Uri->DisplayUri);
+        FBSession^ sess = FBSession::ActiveSession;
+        sess->LogoutAsync();
 
-		FBError^ err = FBError::FromJson(ref new String(ErrorObjectJson));
-		_dialogResponse = ref new FBResult(err);
-	}
+        FBError^ err = FBError::FromJson(ref new String(ErrorObjectJsonLogout));
+        _dialogResponse = ref new FBResult(err);
+    }
     else if (IsDialogCloseRedirect(e->Uri))
     {
         UninitDialog();
@@ -516,6 +521,17 @@ void FacebookDialog::dialogWebView_RequestNavStarting(
             _dialogResponse = ref new FBResult(err);
         }
     }
+    else if (IsLogoutRedirect(e->Uri))
+    {
+        UninitDialog();
+
+        DebugPrintLine(L"Request response is " + e->Uri->DisplayUri);
+        FBSession^ sess = FBSession::ActiveSession;
+        sess->LogoutAsync();
+
+        FBError^ err = FBError::FromJson(ref new String(ErrorObjectJsonLogout));
+        _dialogResponse = ref new FBResult(err);
+    }
     else if (IsDialogCloseRedirect(e->Uri))
     {
         UninitDialog();
@@ -542,6 +558,17 @@ void FacebookDialog::dialogWebView_SendNavStarting(
         DebugPrintLine(L"Request response is " + e->Uri->DisplayUri);
         _dialogResponse = ref new FBResult(ref new FBSendRequest());
 
+    }
+    else if (IsLogoutRedirect(e->Uri))
+    {
+        UninitDialog();
+
+        DebugPrintLine(L"Request response is " + e->Uri->DisplayUri);
+        FBSession^ sess = FBSession::ActiveSession;
+        sess->LogoutAsync();
+
+        FBError^ err = FBError::FromJson(ref new String(ErrorObjectJsonLogout));
+        _dialogResponse = ref new FBResult(err);
     }
     else if (IsDialogCloseRedirect(e->Uri))
     {

--- a/winsdkfb/winsdkfb/winsdkfb.Shared/FacebookDialog.xaml.h
+++ b/winsdkfb/winsdkfb/winsdkfb.Shared/FacebookDialog.xaml.h
@@ -128,6 +128,10 @@ namespace winsdkfb
             Windows::Foundation::Uri^ Response
             );
 
+		bool IsLogoutRedirect(
+			Windows::Foundation::Uri^ Response
+			);
+
         bool IsDialogCloseRedirect(
             Windows::Foundation::Uri^ Response
             );

--- a/winsdkfb/winsdkfb/winsdkfb.Shared/FacebookDialog.xaml.h
+++ b/winsdkfb/winsdkfb/winsdkfb.Shared/FacebookDialog.xaml.h
@@ -128,9 +128,9 @@ namespace winsdkfb
             Windows::Foundation::Uri^ Response
             );
 
-		bool IsLogoutRedirect(
-			Windows::Foundation::Uri^ Response
-			);
+        bool IsLogoutRedirect(
+            Windows::Foundation::Uri^ Response
+            );
 
         bool IsDialogCloseRedirect(
             Windows::Foundation::Uri^ Response


### PR DESCRIPTION
Fix when using Facebook Menu to log out in a FeedDialog (the www.facebook.com/logout.php is called but the token wasn't deleted).