### PR TITLE
FacebookDialog improvement: polling -> async with task_completion_event

### DIFF
--- a/winsdkfb/winsdkfb/winsdkfb.Shared/FacebookDialog.xaml.h
+++ b/winsdkfb/winsdkfb/winsdkfb.Shared/FacebookDialog.xaml.h
@@ -47,27 +47,24 @@ namespace winsdkfb
         void UninitDialog(
             );
 
-        winsdkfb::FBResult^ GetDialogResponse(
-            );
-
-        void ShowLoginDialog(
+        Windows::Foundation::IAsyncOperation<winsdkfb::FBResult^>^ ShowLoginDialog(
             Windows::Foundation::Collections::PropertySet^ Parameters
             );
 
-        void ShowFeedDialog(
+        Windows::Foundation::IAsyncOperation<winsdkfb::FBResult^>^ ShowFeedDialog(
             Windows::Foundation::Collections::PropertySet^ Parameters
             );
 
-        void ShowRequestsDialog(
+        Windows::Foundation::IAsyncOperation<winsdkfb::FBResult^>^ ShowRequestsDialog(
             Windows::Foundation::Collections::PropertySet^ Parameters
             );
 
-        void ShowSendDialog(
+        Windows::Foundation::IAsyncOperation<winsdkfb::FBResult^>^ ShowSendDialog(
             Windows::Foundation::Collections::PropertySet^ Parameters
             );
 
     private:
-        void ShowDialog(
+        Windows::Foundation::IAsyncOperation<winsdkfb::FBResult^>^ ShowDialog(
             DialogUriBuilder^ uriBuilder,
             Windows::Foundation::TypedEventHandler<Windows::UI::Xaml::Controls::WebView^, Windows::UI::Xaml::Controls::WebViewNavigationStartingEventArgs^>^ EventHandler,
             Windows::Foundation::Collections::PropertySet^ Parameters
@@ -141,12 +138,14 @@ namespace winsdkfb
             Windows::UI::Core::WindowSizeChangedEventArgs ^args
             );
 
+        void SetDialogResponse(winsdkfb::FBResult ^dialogResponse);
+
         Windows::Foundation::EventRegistrationToken
             navigatingEventHandlerRegistrationToken;
         Windows::Foundation::EventRegistrationToken
             sizeChangedEventRegistrationToken;
         Windows::UI::Xaml::Controls::Grid^ _grid;
         Windows::UI::Xaml::Controls::Primitives::Popup^ _popup;
-        winsdkfb::FBResult^ _dialogResponse;
+        concurrency::task_completion_event<winsdkfb::FBResult^> _dialogResponse;
     };
 }

--- a/winsdkfb/winsdkfb/winsdkfb.Shared/FacebookSession.cpp
+++ b/winsdkfb/winsdkfb/winsdkfb.Shared/FacebookSession.cpp
@@ -538,7 +538,7 @@ task<FBResult^> FBSession::ShowLoginDialog(
         try
         {
             _dialog = ref new FacebookDialog();
-            create_task(_dialog->ShowSendDialog(Parameters)).then([=](FBResult ^result)
+            create_task(_dialog->ShowLoginDialog(Parameters)).then([=](FBResult ^result)
             {
                 dialogResponse.set(result);
             });

--- a/winsdkfb/winsdkfb/winsdkfb.Shared/FacebookSession.cpp
+++ b/winsdkfb/winsdkfb/winsdkfb.Shared/FacebookSession.cpp
@@ -95,7 +95,6 @@ FBSession::FBSession() :
     {
         login_evt = CreateEventEx(NULL, NULL, 0, DELETE | SYNCHRONIZE);
     }
-    _showingDialog = FALSE;
     _APIMajorVersion = 2;
     _APIMinorVersion = 1;
 }
@@ -408,233 +407,166 @@ IAsyncOperation<FBResult^>^ FBSession::ShowFeedDialogAsync(
     PropertySet^ Parameters
     )
 {
-    _dialog = ref new FacebookDialog();
-
-    _showingDialog = TRUE;
+    concurrency::task_completion_event<FBResult^> dialogResponse;
 
     auto callback = ref new DispatchedHandler(
         [=]()
     {
         try
         {
-            _dialog->ShowFeedDialog(Parameters);
+            _dialog = ref new FacebookDialog();
+            create_task(_dialog->ShowFeedDialog(Parameters)).then([=](FBResult ^result)
+            {
+                dialogResponse.set(result);
+            });
         }
         catch(Exception^ ex)
         {
-            _showingDialog = FALSE;
+            FBError^ err = FBError::FromJson(ref new String(ErrorObjectJson));
+            dialogResponse.set(ref new FBResult(err));
         }
     });
 
     Windows::UI::Core::CoreWindow^ wnd = CoreApplication::MainView->CoreWindow;
 
-    IAsyncAction^ waiter = wnd->Dispatcher->RunAsync(
+    wnd->Dispatcher->RunAsync(
         Windows::UI::Core::CoreDispatcherPriority::Normal,
         callback);
 
-    // create a task that will wait for the login control to finish doing what it was doing
-    IAsyncOperation<FBResult^>^ task = concurrency::create_async(
+    return create_async(
         [=]()
     {
-        FBResult^ dialogResponse = nullptr;
-
-        // TODO: Is there a better way to do this?  I was using an event, but
-        // the concurrency event object was deprecated in the Win10 SDK tools.
-        // Switched to plain old Windows event, but that didn't work at all,
-        // so polling for now.
-        while (_showingDialog && !dialogResponse)
+        return create_task(dialogResponse).then([=](FBResult ^result)
         {
-            dialogResponse = _dialog->GetDialogResponse();
-            Sleep(0);
-        }
-
-        if (!_showingDialog)
-        {
-            FBError^ err = FBError::FromJson(ref new String(ErrorObjectJson));
-            dialogResponse = ref new FBResult(err);
-        }
-
-        _showingDialog = FALSE;
-        _dialog = nullptr;
-        return dialogResponse;
+            _dialog = nullptr;
+            return result;
+        });
     });
-
-    return task;
 }
 
 IAsyncOperation<FBResult^>^ FBSession::ShowRequestsDialogAsync(
     PropertySet^ Parameters
     )
 {
-    _dialog = ref new FacebookDialog();
-
-    _showingDialog = TRUE;
+    concurrency::task_completion_event<FBResult^> dialogResponse;
 
     auto callback = ref new DispatchedHandler(
         [=]()
     {
         try
         {
-            _dialog->ShowRequestsDialog(Parameters);
+            _dialog = ref new FacebookDialog();
+            create_task(_dialog->ShowRequestsDialog(Parameters)).then([=](FBResult ^result)
+            {
+                dialogResponse.set(result);
+            });
         }
         catch(Exception^ ex)
         {
-            _showingDialog = FALSE;
+            FBError^ err = FBError::FromJson(ref new String(ErrorObjectJson));
+            dialogResponse.set(ref new FBResult(err));
         }
     });
 
     Windows::UI::Core::CoreWindow^ wnd = CoreApplication::MainView->CoreWindow;
 
-    IAsyncAction^ waiter = wnd->Dispatcher->RunAsync(
+    wnd->Dispatcher->RunAsync(
         Windows::UI::Core::CoreDispatcherPriority::Normal,
         callback);
 
-    // create a task that will wait for the login control to finish doing what it was doing
-    IAsyncOperation<FBResult^>^ task = concurrency::create_async(
-        [=]() 
+    return create_async(
+        [=]()
     {
-        FBResult^ dialogResponse = nullptr;
-
-        // TODO: Is there a better way to do this?  I was using an event, but
-        // the concurrency event object was deprecated in the Win10 SDK tools.
-        // Switched to plane old Windows event, but that didn't work at all,
-        // so polling for now.
-        while (_showingDialog && !dialogResponse)
+        return create_task(dialogResponse).then([=](FBResult ^result)
         {
-            dialogResponse = _dialog->GetDialogResponse();
-            Sleep(0);
-        }
-
-        if (!_showingDialog)
-        {
-            FBError^ err = FBError::FromJson(ref new String(ErrorObjectJson));
-            dialogResponse = ref new FBResult(err);
-        }
-
-        _showingDialog = FALSE;
-        _dialog = nullptr;
-        return dialogResponse;
+            _dialog = nullptr;
+            return result;
+        });
     });
-
-    return task;
 }
 
 IAsyncOperation<FBResult^>^ FBSession::ShowSendDialogAsync(
     PropertySet^ Parameters
     )
 {
-    _dialog = ref new FacebookDialog();
-
-    _showingDialog = TRUE;
+    concurrency::task_completion_event<FBResult^> dialogResponse;
 
     auto callback = ref new DispatchedHandler(
         [=]()
     {
         try
         {
-            _dialog->ShowSendDialog(Parameters);
+            _dialog = ref new FacebookDialog();
+            create_task(_dialog->ShowSendDialog(Parameters)).then([=](FBResult ^result)
+            {
+                dialogResponse.set(result);
+            });
         }
         catch(Exception^ ex)
         {
-            _showingDialog = FALSE;
+            FBError^ err = FBError::FromJson(ref new String(ErrorObjectJson));
+            dialogResponse.set(ref new FBResult(err));
         }
     });
 
     Windows::UI::Core::CoreWindow^ wnd = CoreApplication::MainView->CoreWindow;
 
-    IAsyncAction^ waiter = wnd->Dispatcher->RunAsync(
+    wnd->Dispatcher->RunAsync(
         Windows::UI::Core::CoreDispatcherPriority::Normal,
         callback);
 
-    // create a task that will wait for the login control to finish doing what it was doing
-    IAsyncOperation<FBResult^>^ task = concurrency::create_async(
-        [=]() 
+    return create_async(
+        [=]()
     {
-        FBResult^ dialogResponse = nullptr;
-
-        // TODO: Is there a better way to do this?  I was using an event, but
-        // the concurrency event object was deprecated in the Win10 SDK tools.
-        // Switched to plane old Windows event, but that didn't work at all,
-        // so polling for now.
-        while (_showingDialog && !dialogResponse)
+        return create_task(dialogResponse).then([=](FBResult ^result)
         {
-            dialogResponse = _dialog->GetDialogResponse();
-            Sleep(0);
-        }
-
-        if (!_showingDialog)
-        {
-            FBError^ err = FBError::FromJson(ref new String(ErrorObjectJson));
-            dialogResponse = ref new FBResult(err);
-        }
-
-        _showingDialog = FALSE;
-        _dialog = nullptr;
-        return dialogResponse;
+            _dialog = nullptr;
+            return result;
+        });
     });
-
-    return task;
 }
 
 task<FBResult^> FBSession::ShowLoginDialog(
     PropertySet^ Parameters
     )
 {
-    _dialog = ref new FacebookDialog();
-
-    _showingDialog = TRUE;
+    concurrency::task_completion_event<FBResult^> dialogResponse;
 
     auto callback = ref new DispatchedHandler(
         [=]()
     {
         try
         {
-            _dialog->ShowLoginDialog(Parameters);
+            _dialog = ref new FacebookDialog();
+            create_task(_dialog->ShowSendDialog(Parameters)).then([=](FBResult ^result)
+            {
+                dialogResponse.set(result);
+            });
         }
         catch (Exception^ ex)
         {
-            _showingDialog = FALSE;
+            FBError^ err = FBError::FromJson(ref new String(ErrorObjectJson));
+            dialogResponse.set(ref new FBResult(err));
         }
     });
 
-    Windows::UI::Core::CoreWindow^ wnd = 
-        Windows::ApplicationModel::Core::CoreApplication::MainView->CoreWindow;
+    Windows::UI::Core::CoreWindow^ wnd = CoreApplication::MainView->CoreWindow;
 
-    IAsyncAction^ waiter = wnd->Dispatcher->RunAsync(
+    wnd->Dispatcher->RunAsync(
         Windows::UI::Core::CoreDispatcherPriority::Normal,
         callback);
 
-    // create a task that will wait for the login control to finish doing what it was doing
-    return create_task([=]()
+
+    return create_task(dialogResponse).then([=](FBResult ^result)
     {
-        FBResult^ dialogResponse = nullptr;
-
-        // TODO: Is there a better way to do this?  I was using an event, but
-        // the concurrency event object was deprecated in the Win10 SDK tools.
-        // Switched to plane old Windows event, but that didn't work at all,
-        // so polling for now.
-        while (_showingDialog && !dialogResponse)
+        if (result->Succeeded)
         {
-            dialogResponse = _dialog->GetDialogResponse();
-            Sleep(0);
-        } 
-
-        if (_showingDialog)
-        {
-            if (dialogResponse->Succeeded)
-            {
-                AccessTokenData =
-                    static_cast<FBAccessTokenData^>(dialogResponse->Object);
-            }
-        }
-        else
-        {
-            FBError^ err = FBError::FromJson(ref new String(ErrorObjectJson));
-            dialogResponse = ref new FBResult(err);
+            AccessTokenData =
+                static_cast<FBAccessTokenData^>(result->Object);
         }
 
-        _showingDialog = FALSE;
         _dialog = nullptr;
-        return dialogResponse;
+        return result;
     });
 }
 

--- a/winsdkfb/winsdkfb/winsdkfb.Shared/FacebookSession.h
+++ b/winsdkfb/winsdkfb/winsdkfb.Shared/FacebookSession.h
@@ -272,7 +272,6 @@ namespace winsdkfb
             winsdkfb::Graph::FBUser^ _user;
             concurrency::task<winsdkfb::FBResult^> _loginTask;
             winsdkfb::FacebookDialog^ _dialog;
-            BOOL _showingDialog;
             int _APIMajorVersion;
             int _APIMinorVersion;
     };


### PR DESCRIPTION
Hi!
I noticed that functions `FBSession::Show*DialogAsync()` use polling loop while waiting for `FacebookDialog`. I decided to rewrite that part in a more async way using `IAsyncOperation` and `task_completion_event`. Now there is no need for `FacebookDialog::GetDialogResponse()` and the code looks cleaner.
I also moved `FacebookDialog` creation to the UI thread, because its components are required to be initialized in the UI thread anyway.