### PR TITLE
Fixing #130 when close button is occluded by status bar

### DIFF
--- a/winsdkfb/winsdkfb/winsdkfb.Shared/FacebookDialog.xaml
+++ b/winsdkfb/winsdkfb/winsdkfb.Shared/FacebookDialog.xaml
@@ -17,7 +17,7 @@
         </ResourceDictionary>
     </UserControl.Resources>
     <Grid x:Name="LayoutRoot" Background="#00000000">
-        <Grid MaxWidth="512" MaxHeight="500">
+        <Grid MaxWidth="512" MaxHeight="480">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="*"/>


### PR DESCRIPTION
Simple fix for #130 by making the login dialog smaller so it is never occluded by status bar on phone.