### PR TITLE
modified config to support kramdown markdown rendering

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,5 +6,6 @@
 # 'jekyll serve'. If you change this file, please restart the server process.
 
 # Build settings
+markdown: kramdown
 highlighter: pygments
 permalink: pretty


### PR DESCRIPTION
Deleting the "markdown" option in the _config.yml file (as specified by GitHub pages support) breaks some of the markdown heading rendering in the documentation site. Switching to "kramdown" which is the markdown engine gh-pages will support after May 1.