### PR TITLE
suppressed WebAuthenticationBroker::AuthenticateAsync warning

### DIFF
--- a/winsdkfb/winsdkfb/winsdkfb.Shared/FacebookSession.cpp
+++ b/winsdkfb/winsdkfb/winsdkfb.Shared/FacebookSession.cpp
@@ -827,6 +827,10 @@ task<FBResult^> FBSession::RunOAuthOnUiThread(
         Windows::UI::Core::CoreDispatcherPriority::Normal,
         ref new Windows::UI::Core::DispatchedHandler([=]()
     {
+// disable warning for WebAuthenticationBroker::AuthenticateAsync being marked
+// as deprecated on wp8.1
+#pragma warning(push)
+#pragma warning(disable: 4973)
         _loginTask = create_task(
             WebAuthenticationBroker::AuthenticateAsync(
             WebAuthenticationOptions::None, BuildLoginUri(Parameters),
@@ -836,6 +840,7 @@ task<FBResult^> FBSession::RunOAuthOnUiThread(
             return ProcessAuthResult(authResult);
         });
     })));
+#pragma warning(pop)
 
     return create_task([=](void)
     {


### PR DESCRIPTION
#104
`WebAuthenticationBroker::AuthenticateAsync` is marked as deprecated for windows phone 8.1, however the behavior of the function changes depending on whether it is a windows 10 or 8.1 phone. Rather than `#ifdef` the call out for windows phone 8.1, the warning is suppressed. Having the function exist in the sdk does not seem to negatively affect the ability of an app to pass Windows App Certification Kit.