### PR TITLE
Add support for app install tracking to the win10_uwp SDK

### DIFF
--- a/winsdkfb/winsdkfb/winsdkfb.Shared/FacebookClient.cpp
+++ b/winsdkfb/winsdkfb/winsdkfb.Shared/FacebookClient.cpp
@@ -48,6 +48,8 @@ using namespace Windows::Web::Http::Headers;
 #define MultiPartNewLine "\r\n"
 #define MultiPartContentType L"Content-Type: multipart/form-data; "
 #define MultiPartBoundary L"------------------------------fbsdk1234567890"
+#define UserAgent L"User-Agent"
+#define WinSDK L"FBWinSDK.0.9"
 
 FBClient::FBClient()
 {
@@ -188,6 +190,7 @@ task<String^> FBClient::GetTaskInternalAsync(
 {
     HttpBaseProtocolFilter^ filter = ref new HttpBaseProtocolFilter();
     HttpClient^ httpClient = ref new HttpClient(filter);
+	httpClient->DefaultRequestHeaders->Append(UserAgent, WinSDK);
     cancellation_token_source cancellationTokenSource =
         cancellation_token_source();
 
@@ -292,6 +295,7 @@ task<String^> FBClient::SimplePostInternalAsync(
 {
     HttpBaseProtocolFilter^ filter = ref new HttpBaseProtocolFilter();
     HttpClient^ httpClient = ref new HttpClient(filter);
+	httpClient->DefaultRequestHeaders->Append(UserAgent, WinSDK);
     cancellation_token_source cancellationTokenSource =
         cancellation_token_source();
 
@@ -396,6 +400,7 @@ task<String^> FBClient::MultipartPostInternalAsync(
     )
 {
     HttpClient^ httpClient = ref new HttpClient();
+	httpClient->DefaultRequestHeaders->Append(UserAgent, WinSDK);
     HttpMultipartFormDataContent^ form =
         ref new HttpMultipartFormDataContent();
     cancellation_token_source cancellationTokenSource =
@@ -498,6 +503,7 @@ task<String^> FBClient::DeleteTaskInternalAsync(
 {
     HttpBaseProtocolFilter^ filter = ref new HttpBaseProtocolFilter();
     HttpClient^ httpClient = ref new HttpClient(filter);
+	httpClient->DefaultRequestHeaders->Append(UserAgent, WinSDK);
     cancellation_token_source cancellationTokenSource =
         cancellation_token_source();
 

--- a/winsdkfb/winsdkfb_uwp/winsdkfb_uwp/FBSDKAppEvents.cpp
+++ b/winsdkfb/winsdkfb_uwp/winsdkfb_uwp/FBSDKAppEvents.cpp
@@ -1,0 +1,188 @@
+//******************************************************************************
+//
+// Copyright (c) 2015 Microsoft Corporation. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//******************************************************************************
+
+#include "pch.h"
+
+#include "FBSDKAppEvents.h"
+#include "FacebookClient.h"
+
+using namespace concurrency;
+using namespace std;
+using namespace winsdkfb;
+
+using namespace Platform;
+using namespace Windows::ApplicationModel::Resources;
+using namespace Windows::ApplicationModel::Store;
+using namespace Windows::Data::Json;
+using namespace Windows::Foundation;
+using namespace Windows::Foundation::Collections;
+using namespace Windows::Globalization;
+using namespace Windows::Storage;
+using namespace Windows::System::UserProfile;
+
+#define FBActivitiesPath L"/activities"
+#define FBMobileAppInstall L"MOBILE_APP_INSTALL"
+#define FBCustomAppEvent L"CUSTOM_APP_EVENTS"
+#define FBAppIDName L"FBApplicationId"
+
+/*
+* To integrate install tracking for mobile app install ads,
+* call this method when the app is launched.
+*/
+void FBSDKAppEvents::ActivateApp()
+{
+    // Try to grab the application id from resource file.
+    String^ appId;
+    try {
+        ResourceLoader^ rl = ResourceLoader::GetForCurrentView();
+        appId = rl->GetString(FBAppIDName);
+    }
+    catch (Exception^ e) {
+        throw ref new NotImplementedException(
+            FBAppIDName + L" needs to be added to resource file."
+        );
+    }
+
+    if (!appId) {
+        throw ref new NotImplementedException(
+            FBAppIDName + L" cannot contain empty value"
+        );
+    }
+
+    create_task(FBSDKAppEvents::PublishInstall(appId));
+    create_task(FBSDKAppEvents::LogActivateEvent(appId));
+}
+
+/*
+ * Publish an install event to the Facebook graph endpoint.
+ * Write the timestamp to localSettings so we only trigger this once.
+ */
+IAsyncAction^ FBSDKAppEvents::PublishInstall(
+    String^ AppId
+    )
+{
+    String^ lastPingKey = L"LastAttributionPing" + AppId;
+    String^ lastResponseKey = L"LastInstallResponse" + AppId;
+    ApplicationDataContainer^ localSettings = ApplicationData::Current->LocalSettings;
+    String^ pingTime = safe_cast<String^>(localSettings->Values->Lookup(lastPingKey));
+
+    return create_async([=]() -> void
+    {
+        if (!pingTime) {
+            create_task(FBSDKAppEvents::LogInstallEvent(AppId))
+                .then([=](String^ lastAttributionResponse) -> void
+            {
+                // Set last ping time
+                Calendar^ calendar = ref new Calendar();
+                calendar->SetToNow();
+                INT64 universaltime = calendar->GetDateTime().UniversalTime;
+                localSettings->Values->Insert(
+                    lastPingKey,
+                    dynamic_cast<PropertyValue^>(
+                        PropertyValue::CreateString(universaltime.ToString())
+                    )
+                );
+
+                // Set last response
+                localSettings->Values->Insert(
+                    lastResponseKey,
+                    dynamic_cast<PropertyValue^>(PropertyValue::CreateString(lastAttributionResponse))
+                );
+
+#ifdef _DEBUG
+                String^ msg = L"Mobile App Install Response: " + lastAttributionResponse + L"\n"
+                    L"Mobile App Install Ping Time: " + calendar->GetDateTime() + L"\n";
+                OutputDebugString(msg->Data());
+#endif
+            });
+        }
+    });
+}
+
+/*
+ * Logs an install event to the Facebook graph endpoint.
+ * The user will be looked up using idfa or windows_attribution_id
+ */
+IAsyncOperation<String^>^ FBSDKAppEvents::LogInstallEvent(
+    String^ AppId
+    )
+{
+    String^ path = AppId + FBActivitiesPath;
+    PropertySet^ parameters = ref new PropertySet();
+    parameters->Insert(L"event", FBMobileAppInstall);
+    parameters->Insert(L"advertiser_id", AdvertisingManager::AdvertisingId);
+    parameters->Insert(
+        L"advertiser_tracking_enabled",
+        AdvertisingManager::AdvertisingId->IsEmpty() ? "0" : "1"
+    );
+
+    return create_async([=]() -> task<String^>
+    {
+        return create_task(CurrentApp::GetAppPurchaseCampaignIdAsync())
+            .then([=](String^ campaignID) -> task<String^>
+        {
+            parameters->Insert(L"windows_attribution_id", campaignID);
+            return create_task([=]() -> IAsyncOperation<String^>^
+            {
+                return FBClient::PostTaskAsync(path, parameters);
+            });
+        });
+    });
+}
+
+/*
+ * Logs a custom app event to the Facebook graph endpoint.
+ */
+IAsyncAction^ FBSDKAppEvents::LogActivateEvent(
+    String^ AppId
+    )
+{
+    String^ path = AppId + FBActivitiesPath;
+    PropertySet^ parameters = ref new PropertySet();
+    parameters->Insert(L"event", FBCustomAppEvent);
+    parameters->Insert(L"custom_events", FBSDKAppEvents::GetActivateAppJson());
+    parameters->Insert(L"advertiser_id", AdvertisingManager::AdvertisingId);
+    parameters->Insert(
+        L"advertiser_tracking_enabled",
+        AdvertisingManager::AdvertisingId->IsEmpty() ? "0" : "1"
+    );
+
+    return create_async([=]()
+    {
+        return create_task(FBClient::PostTaskAsync(path, parameters))
+            .then([=](String^ response) -> void
+        {
+#ifdef _DEBUG
+            String^ msg = L"Custom App Event Response: " + response;
+            OutputDebugString(msg->Data());
+#endif
+        });
+    });
+}
+
+/*
+ * Creates a JSON array encapsulating the activate app event
+ */
+String^ FBSDKAppEvents::GetActivateAppJson() {
+    JsonArray^ customEvents = ref new JsonArray();
+    JsonObject^ activateJson = ref new JsonObject();
+    activateJson->SetNamedValue(
+        L"_eventName",
+        JsonValue::CreateStringValue(L"fb_mobile_activate_app")
+    );
+    customEvents->Append(activateJson);
+    return customEvents->ToString();
+}

--- a/winsdkfb/winsdkfb_uwp/winsdkfb_uwp/FBSDKAppEvents.h
+++ b/winsdkfb/winsdkfb_uwp/winsdkfb_uwp/FBSDKAppEvents.h
@@ -1,0 +1,41 @@
+//******************************************************************************
+//
+// Copyright (c) 2015 Microsoft Corporation. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//******************************************************************************
+
+#pragma once
+
+namespace winsdkfb
+{
+    public ref class FBSDKAppEvents sealed
+    {
+    public:
+        static void ActivateApp();
+
+    private:
+        static Windows::Foundation::IAsyncAction^ PublishInstall(
+            Platform::String^ AppId
+            );
+
+        static Windows::Foundation::IAsyncAction^ LogActivateEvent(
+            Platform::String^ AppId
+            );
+
+        static Windows::Foundation::IAsyncOperation<Platform::String^>^ LogInstallEvent(
+            Platform::String^ AppId
+            );
+
+        static Platform::String^ GetActivateAppJson();
+    };
+}

--- a/winsdkfb/winsdkfb_uwp/winsdkfb_uwp/winsdkfb_uwp.vcxproj
+++ b/winsdkfb/winsdkfb_uwp/winsdkfb_uwp/winsdkfb_uwp.vcxproj
@@ -26,6 +26,12 @@
       <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="FBSDKAppEvents.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="FBSDKAppEvents.cpp" />
+  </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{973a943b-ff77-4267-8f30-f5fe2b7f5583}</ProjectGuid>
     <Keyword>WindowsRuntimeComponent</Keyword>

--- a/winsdkfb/winsdkfb_uwp/winsdkfb_uwp/winsdkfb_uwp.vcxproj.filters
+++ b/winsdkfb/winsdkfb_uwp/winsdkfb_uwp/winsdkfb_uwp.vcxproj.filters
@@ -5,5 +5,21 @@
       <UniqueIdentifier>0202dd37-491a-4b84-b842-aca9db7b8d61</UniqueIdentifier>
       <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tga;tiff;tif;png;wav;mfcribbon-ms</Extensions>
     </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{aab3821e-08d7-4787-99a1-c8f5e3c90f03}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{0c41c025-6e0c-405d-b80a-46adadface88}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="FBSDKAppEvents.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="FBSDKAppEvents.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- Updating the User-Agent so we can identify the caller. Let me know if there's preferred naming/version management. 
- Developer should call ActivateApp() on app launch. Install is logged on first open, a fb_mobile_activate_app custom app event on every open.  