### PR TITLE
SessionLoginBehavior::Silent login/logout toggling behavior fix

### DIFF
--- a/winsdkfb/winsdkfb/winsdkfb.Shared/FacebookPermissions.cpp
+++ b/winsdkfb/winsdkfb/winsdkfb.Shared/FacebookPermissions.cpp
@@ -17,16 +17,26 @@
 
 #include "pch.h"
 #include "FacebookPermissions.h"
+#include <sstream>
 
 using namespace winsdkfb;
 using namespace Platform;
+using namespace Platform::Collections;
 using namespace Windows::Foundation::Collections;
+using namespace std;
 
 FBPermissions::FBPermissions(
     IVectorView<String^>^ Permissions
     )
 {
     _values = Permissions;
+}
+
+FBPermissions^ FBPermissions::FromString(
+    String^ Permissions
+    )
+{
+    return ref new FBPermissions(ParsePermissionsFromString(Permissions));
 }
 
 IVectorView<String^>^ FBPermissions::Values::get()
@@ -56,4 +66,49 @@ Platform::String^ FBPermissions::ToString(
 	return permissions;
 }
 
+IVectorView<String^>^ FBPermissions::ParsePermissionsFromString(
+    String^ Permissions
+    )
+{
+    const int bufferSize = 64;
+    wstring wstringPermissions = Permissions->Data();
+    wstringstream wss{wstringPermissions};
+    Vector<String^>^ parsedPermissions = ref new Vector<String^>();
+    wchar_t temp[bufferSize];
+    while (true)
+    {
+        if (wss.eof())
+        {
+            break;
+        }
+        wss.getline(temp, bufferSize, L',');
+        parsedPermissions->Append(ref new String(temp));
+    }
+    return parsedPermissions->GetView();
+}
 
+FBPermissions^ FBPermissions::Difference(
+    FBPermissions^ Minuend,
+    FBPermissions^ Subtrahend
+    )
+{
+    Vector<String^>^ remainingPermissions = ref new Vector<String^>();
+    // stick each permissions into vector manually since copy constructor won't work with IVectorView
+    for (String^ perm : Minuend->Values)
+    {
+        remainingPermissions->Append(perm);
+    }
+    for (String^ otherPerm : Subtrahend->Values)
+    {
+        for (int i = 0; i < remainingPermissions->Size; ++i)
+        {
+            String^ perm = remainingPermissions->GetAt(i);
+            if (String::CompareOrdinal(perm, otherPerm) == 0)
+            {
+                remainingPermissions->RemoveAt(i);
+                break;
+            }
+        }
+    }
+    return ref new FBPermissions(remainingPermissions->GetView());
+}

--- a/winsdkfb/winsdkfb/winsdkfb.Shared/FacebookPermissions.h
+++ b/winsdkfb/winsdkfb/winsdkfb.Shared/FacebookPermissions.h
@@ -17,7 +17,7 @@
 
 namespace winsdkfb
 {
-    /*!\brief Simple class to contain a set of permissions for FB.  
+    /*!\brief Simple class to contain a set of permissions for FB.
     */
     public ref class FBPermissions sealed
 	{
@@ -38,8 +38,28 @@ namespace winsdkfb
 			virtual Platform::String^ ToString(
 				) override;
 
+            /**
+             * Constructs an instance of FBPermissions
+             * @param Permissions A comma seperated list of permissions
+             */
+            static FBPermissions^ FromString(
+                Platform::String^ Permissions
+                );
+
+            /**
+             * Returns the set difference of two FBPermissions' permissions
+             * @param Minuend FBPermissions to subtract from
+             * @param Subtrahend FBPermissions to 'remove' from Minuend
+             * @return a new FBPermissions object that contains the set of
+             * permissions that exist in Minuend and not in Subtrahend
+             */
+            static FBPermissions^ Difference(FBPermissions^ Minuend, FBPermissions^ Subtrahend);
+
 		private:
+            static Windows::Foundation::Collections::IVectorView<Platform::String^>^ ParsePermissionsFromString(
+                Platform::String^ Permissions
+                );
+
 			Windows::Foundation::Collections::IVectorView<Platform::String^>^ _values;
 	};
 }
-


### PR DESCRIPTION
Fix for #169 . `FBSession::LoginAsync` will now also fail to login if the saved access token does not grant all of the permissions that are being requested.