### PR TITLE
ProfilePictureControl::UserId dependency property

### DIFF
--- a/samples/LoginCpp-UWP/LoginCpp/UserInfo.xaml
+++ b/samples/LoginCpp-UWP/LoginCpp/UserInfo.xaml
@@ -41,7 +41,7 @@
                 <StackPanel Grid.Row="2" x:Name="ContentRoot" Orientation="Vertical" Margin="19,0,19,0">
                     <StackPanel Orientation="Horizontal">
                         <TextBlock Text="ID:" Margin="0,12,6,0" FontWeight="Bold"/>
-                        <TextBlock x:Name="UserId" Text="&lt;not set&gt;" Margin="0,12,0,0" IsRightTapEnabled="True" IsTextSelectionEnabled="True"/>
+                        <TextBlock x:Name="UserId" Text="{Binding UserId, ElementName=SquarePicture}" Margin="0,12,0,0" IsRightTapEnabled="True" IsTextSelectionEnabled="True"/>
                     </StackPanel>
                     <StackPanel Orientation="Horizontal">
                         <TextBlock Text="First Name:" Margin="0,12,6,0" FontWeight="Bold"/>

--- a/samples/LoginCpp-UWP/LoginCpp/UserInfo.xaml.cpp
+++ b/samples/LoginCpp-UWP/LoginCpp/UserInfo.xaml.cpp
@@ -98,7 +98,8 @@ void UserInfo::OnNavigatedTo(NavigationEventArgs^ e)
         FBUser^ user = sess->User;
         if (user)
         {
-            UserId->Text = user->Id;
+            // Don't set the UserId, let data-binding update it
+            // UserId->Text = user->Id;
             UserFirstName->Text = user->FirstName;
             UserGender->Text = user->Gender;
             UserLastName->Text = user->LastName;

--- a/samples/LoginCpp/LoginCpp/LoginCpp.Shared/UserInfo.Shared.xaml.cpp
+++ b/samples/LoginCpp/LoginCpp/LoginCpp.Shared/UserInfo.Shared.xaml.cpp
@@ -60,7 +60,8 @@ void UserInfo::OnNavigatedTo(NavigationEventArgs^ e)
         FBUser^ user = sess->User;
         if (user)
         {
-            UserId->Text = user->Id;
+            // Don't set the UserId, let DataBinding take care of it
+            // UserId->Text = user->Id;
             UserFirstName->Text = user->FirstName;
             UserGender->Text = user->Gender;
             UserLastName->Text = user->LastName;

--- a/samples/LoginCpp/LoginCpp/LoginCpp.Windows/UserInfo.xaml
+++ b/samples/LoginCpp/LoginCpp/LoginCpp.Windows/UserInfo.xaml
@@ -42,7 +42,7 @@
                 <StackPanel Grid.Row="2" x:Name="ContentRoot" Orientation="Vertical" Margin="19,0,19,0">
                     <StackPanel Orientation="Horizontal">
                         <TextBlock FontSize="14" Text="ID:" Margin="0,12,6,0" FontWeight="Bold"/>
-                        <TextBlock FontSize="14" x:Name="UserId" Text="&lt;not set&gt;" Margin="0,12,0,0" IsRightTapEnabled="True" IsTextSelectionEnabled="True"/>
+                        <TextBlock FontSize="14" x:Name="UserId" Text="{Binding UserId, ElementName=SquarePicture}" Margin="0,12,0,0" IsRightTapEnabled="True" IsTextSelectionEnabled="True"/>
                     </StackPanel>
                     <StackPanel Orientation="Horizontal">
                         <TextBlock FontSize="14" Text="First Name:" Margin="0,12,6,0" FontWeight="Bold"/>

--- a/samples/LoginCs/LoginCs/LoginCs.Shared/UserInfo.xaml.cs
+++ b/samples/LoginCs/LoginCs/LoginCs.Shared/UserInfo.xaml.cs
@@ -54,7 +54,9 @@ namespace LoginCs
                 if (FBSession.ActiveSession.User != null)
                 {
                     FBUser user = FBSession.ActiveSession.User;
-                    UserId.Text = user.Id;
+
+                    // Don't set the UserId, let DataBinding take care of it
+                    // UserId.Text = user.Id;
                     UserFirstName.Text = user.FirstName;
                     UserGender.Text = user.Gender;
                     UserLastName.Text = user.LastName;

--- a/samples/LoginCs/LoginCs/LoginCs.Windows/UserInfo.xaml
+++ b/samples/LoginCs/LoginCs/LoginCs.Windows/UserInfo.xaml
@@ -41,7 +41,7 @@
                 <StackPanel Grid.Row="2" x:Name="ContentRoot" Orientation="Vertical" Margin="19,0,19,0">
                     <StackPanel Orientation="Horizontal">
                         <TextBlock FontSize="14" Text="ID:" Margin="0,12,6,0" FontWeight="Bold"/>
-                        <TextBlock FontSize="14" x:Name="UserId" Text="&lt;not set&gt;" Margin="0,12,0,0" IsRightTapEnabled="True" IsTextSelectionEnabled="True"/>
+                        <TextBlock FontSize="14" x:Name="UserId" Text="{Binding UserId, ElementName=SquarePicture}" Margin="0,12,0,0" IsRightTapEnabled="True" IsTextSelectionEnabled="True"/>
                     </StackPanel>
                     <StackPanel Orientation="Horizontal">
                         <TextBlock FontSize="14" Text="First Name:" Margin="0,12,6,0" FontWeight="Bold"/>

--- a/winsdkfb/winsdkfb/winsdkfb.Shared/FacebookProfilePictureControl.xaml.cpp
+++ b/winsdkfb/winsdkfb/winsdkfb.Shared/FacebookProfilePictureControl.xaml.cpp
@@ -55,7 +55,7 @@ using namespace Windows::UI::Xaml::Interop;
 DependencyProperty^ ProfilePictureControl::_userIdProperty = DependencyProperty::Register(
     L"UserId",
     TypeName(String::typeid),
-    TypeName(String::typeid),
+    TypeName(ProfilePictureControl::typeid),
     ref new PropertyMetadata(
         nullptr,
         ref new PropertyChangedCallback(&ProfilePictureControl::UserIdPropertyChanged)));

--- a/winsdkfb/winsdkfb/winsdkfb.Shared/FacebookProfilePictureControl.xaml.cpp
+++ b/winsdkfb/winsdkfb/winsdkfb.Shared/FacebookProfilePictureControl.xaml.cpp
@@ -42,6 +42,7 @@ using namespace Windows::UI::Xaml::Input;
 using namespace Windows::UI::Xaml::Media;
 using namespace Windows::UI::Xaml::Navigation;
 using namespace Windows::UI::Xaml::Media::Imaging;
+using namespace Windows::UI::Xaml::Interop;
 
 // At least enough characters to hold a string representation of 32-bit int,
 // in decimal.  Used for width and height of profile picture.
@@ -51,30 +52,36 @@ using namespace Windows::UI::Xaml::Media::Imaging;
 #define ProfilePictureSillhouetteImage \
     "ms-appx:///winsdkfb/Images/fb_blank_profile_portrait.png"
 
-
-// The User Control item template is documented at http://go.microsoft.com/fwlink/?LinkId=234236
+DependencyProperty^ ProfilePictureControl::_userIdProperty = DependencyProperty::Register(
+    L"UserId",
+    TypeName(String::typeid),
+    TypeName(String::typeid),
+    ref new PropertyMetadata(
+        nullptr,
+        ref new PropertyChangedCallback(&ProfilePictureControl::UserIdPropertyChanged)));
 
 ProfilePictureControl::ProfilePictureControl() :
-    _userIdValid(false),
-    _UserId(nullptr),
     _CropMode(CroppingType::Square)
 {
 	InitializeComponent();
+    Update();
+}
+
+void ProfilePictureControl::UserIdPropertyChanged(DependencyObject^ d, DependencyPropertyChangedEventArgs^ e)
+{
+    ProfilePictureControl^ instance = static_cast<ProfilePictureControl^>(d);
+    instance->UserId = static_cast<String^>(e->NewValue);
 }
 
 String^ ProfilePictureControl::UserId::get()
 {
-    return _UserId;
+    return safe_cast<String^>(GetValue(_userIdProperty));
 }
 
 void ProfilePictureControl::UserId::set(String^ value)
 {
-    _userIdValid = true;
-    if (!_UserId || (String::CompareOrdinal(value, _UserId) == 0))
-    {
-        _UserId = value;
-        Update();
-    }
+    SetValue(_userIdProperty, value);
+    Update();
 }
 
 CroppingType ProfilePictureControl::CropMode::get()
@@ -151,7 +158,7 @@ void ProfilePictureControl::SetImageSourceFromResource()
 
 void ProfilePictureControl::Update()
 {
-    if (UserId && (String::CompareOrdinal(UserId, L"-1") != 0))
+    if (UserId)
     {
         SetImageSourceFromUserId();
     }
@@ -189,13 +196,7 @@ ProfilePictureControl::GetProfilePictureInfo(
             parameters->Insert(L"height", Value);
         }
     }
-
-    if (String::CompareOrdinal(UserId, L"-1") == 0)
-    {
-        // Don't have an ID yet, so we're not logged in.  Display a generic
-        // silhouette a la Facebook.
-    }
-    else
+    if (UserId)
     {
         String^ path = UserId + L"/picture";
 

--- a/winsdkfb/winsdkfb/winsdkfb.Shared/FacebookProfilePictureControl.xaml.h
+++ b/winsdkfb/winsdkfb/winsdkfb.Shared/FacebookProfilePictureControl.xaml.h
@@ -55,6 +55,13 @@ namespace winsdkfb
         }
 
     private:
+        static Windows::UI::Xaml::DependencyProperty^ _userIdProperty;
+
+        static void UserIdPropertyChanged(
+            Windows::UI::Xaml::DependencyObject^ d,
+            Windows::UI::Xaml::DependencyPropertyChangedEventArgs^ e
+            );
+
         void SetImageSourceFromUserId(
             );
 
@@ -70,8 +77,6 @@ namespace winsdkfb
             int height
             );
 
-        bool _userIdValid;
-        String^ _UserId;
         CroppingType _CropMode;
 	};
 }


### PR DESCRIPTION
#58 
`ProfilePictureControl::UserId` is now implemented as a dependency property. Changing its value will update the profile image if successful. If no value is set then a default image will be shown instead of the control remaining blank.