### PR TITLE
FBClient::SerializeParameters uses ToString() as a backup

### DIFF
--- a/samples/LoginCpp-UWP/LoginCpp/LoginCpp.vcxproj
+++ b/samples/LoginCpp-UWP/LoginCpp/LoginCpp.vcxproj
@@ -211,12 +211,12 @@
     <PRIResource Include="Resources.resw" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="..\..\..\winsdkfb\winsdkfb_testing_key.pfx" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\..\..\winsdkfb\winsdkfb_uwp\winsdkfb_uwp\winsdkfb_uwp.vcxproj">
       <Project>{973a943b-ff77-4267-8f30-f5fe2b7f5583}</Project>
     </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="..\..\..\winsdkfb\winsdkfb_testing_key.pfx" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets" />

--- a/samples/LoginCpp-UWP/LoginCpp/LoginCpp.vcxproj.filters
+++ b/samples/LoginCpp-UWP/LoginCpp/LoginCpp.vcxproj.filters
@@ -34,7 +34,6 @@
     <ClCompile Include="FBPageBindable.cpp" />
     <ClCompile Include="UserInfo.xaml.cpp" />
     <ClCompile Include="UserLikes.xaml.cpp" />
-    <ClCompile Include="OptionsPage.xaml.cpp" />
     <ClCompile Include="Dialogs.xaml.cpp" />
   </ItemGroup>
   <ItemGroup>
@@ -47,7 +46,6 @@
     <ClInclude Include="FBPageBindable.h" />
     <ClInclude Include="UserInfo.xaml.h" />
     <ClInclude Include="UserLikes.xaml.h" />
-    <ClInclude Include="OptionsPage.xaml.h" />
     <ClInclude Include="Dialogs.xaml.h" />
   </ItemGroup>
   <ItemGroup>

--- a/winsdkfb/winsdkfb/winsdkfb.Shared/FacebookClient.cpp
+++ b/winsdkfb/winsdkfb/winsdkfb.Shared/FacebookClient.cpp
@@ -654,8 +654,12 @@ void FBClient::SerializeParameters(
     auto item = keysThatAreNotString->First();
     while (item->HasCurrent)
     {
-        // TODO: Jsonize the object value
-        String^ newValue = dynamic_cast<String^>(parameters->Lookup(item->Current));
+        Object^ val = parameters->Lookup(item->Current);
+        String^ newValue = dynamic_cast<String^>(val);
+        if (!newValue)
+        {
+            newValue = val->ToString();
+        }
 
         // Replace the existing object with the new Jsonized value
         parameters->Remove(item->Current);


### PR DESCRIPTION
#156
Expects the user to override the `ToString` method on their custom object to return a valid (probably json) string.