### PR TITLE
Improved FacebookDialog UI for 8.1 projects

### DIFF
--- a/winsdkfb/winsdkfb/winsdkfb.Shared/FacebookDialog.xaml
+++ b/winsdkfb/winsdkfb/winsdkfb.Shared/FacebookDialog.xaml
@@ -18,15 +18,16 @@
     </UserControl.Resources>
 
     <Grid x:Name="LayoutRoot" Background="#7F000000">
-        <Grid Margin="20,40">
+        <Grid Margin="20,40" MaxWidth="650" MaxHeight="600">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="*"/>
             </Grid.RowDefinitions>
+
             <Button Grid.Row="0" x:Name="closeDialogButton" HorizontalAlignment="Right" VerticalAlignment="Top" 
                     MinWidth="0" MinHeight="0" Width="30" Height="30" 
                     Style="{StaticResource CircleWithCrossButtonKey}" Click="CloseDialogButton_OnClick" FontFamily="Segoe UI Symbol" 
-                    Margin="0,0,0,5" Foreground="{ThemeResource ButtonForegroundThemeBrush}"  />
+                    Margin="0,0,0,5" Foreground="White" />
             <WebView x:Name="dialogWebBrowser" Grid.Row="1" />
         </Grid>
     </Grid>

--- a/winsdkfb/winsdkfb/winsdkfb.Shared/FacebookDialog.xaml
+++ b/winsdkfb/winsdkfb/winsdkfb.Shared/FacebookDialog.xaml
@@ -16,14 +16,18 @@
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </UserControl.Resources>
-    <Grid x:Name="LayoutRoot" Background="#00000000">
-        <Grid MaxWidth="512" MaxHeight="500">
+
+    <Grid x:Name="LayoutRoot" Background="#7F000000">
+        <Grid Margin="20,40">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="*"/>
             </Grid.RowDefinitions>
-            <Button Grid.Row="0"  x:Name="closeDialogButton" HorizontalAlignment="Right" Height="13" VerticalAlignment="Top" Width="13" Style="{StaticResource CircleWithCrossButtonKey}" Click="CloseDialogButton_OnClick" FontFamily="Segoe UI Symbol" Margin="0,0,15,0" Foreground="{ThemeResource ButtonForegroundThemeBrush}"  />
-            <WebView x:Name="dialogWebBrowser" Grid.Row="1" Margin="10" />
+            <Button Grid.Row="0" x:Name="closeDialogButton" HorizontalAlignment="Right" VerticalAlignment="Top" 
+                    MinWidth="0" MinHeight="0" Width="30" Height="30" 
+                    Style="{StaticResource CircleWithCrossButtonKey}" Click="CloseDialogButton_OnClick" FontFamily="Segoe UI Symbol" 
+                    Margin="0,0,0,5" Foreground="{ThemeResource ButtonForegroundThemeBrush}"  />
+            <WebView x:Name="dialogWebBrowser" Grid.Row="1" />
         </Grid>
     </Grid>
 </UserControl>


### PR DESCRIPTION
Fixed close button that appears stretched on Windows Phone 8.1.
Other improvements to look better.