### PR TITLE
Minor tweaks based on usage of sdk

### DIFF
--- a/winsdkfb/winsdkfb/winsdkfb.Shared/FacebookSession.cpp
+++ b/winsdkfb/winsdkfb/winsdkfb.Shared/FacebookSession.cpp
@@ -160,6 +160,9 @@ FBAccessTokenData^ FBSession::AccessTokenData::get()
 void FBSession::AccessTokenData::set(FBAccessTokenData^ value)
 {
     _AccessTokenData = value;
+
+    // If token have been updated, make sure to save updated token
+    TrySaveTokenData();
 }
 
 FBUser^ FBSession::User::get()

--- a/winsdkfb/winsdkfb/winsdkfb.Shared/FacebookSession.cpp
+++ b/winsdkfb/winsdkfb/winsdkfb.Shared/FacebookSession.cpp
@@ -964,7 +964,6 @@ IAsyncOperation<FBResult^>^ FBSession::LoginAsync(
     {
         Permissions = ref new FBPermissions((ref new Vector<String^>())->GetView());
     }
-    _dialog = ref new FacebookDialog();
 
     return create_async([=]()
     {


### PR DESCRIPTION
I would like to suggest these two minor changes.

1. Try and save the token data after having set a new token, like in a scenario in which the token gets extended. Either like in this PR by calling TrySaveTokenData in setter, or by changing access level of TrySaveTokenData to public and allow external code to call.

2. Don't instatiate the FacebookDialog too early, we've had some issue on which the app is trying to silently reauthenticate when app is launching, but from a background thread, which causes the instantiation of FacebookDialog to throw exception. Instantiation is already being handled by actual dialog calls.