### PR TITLE
Using TryGetItemAsync when Win10

### DIFF
--- a/winsdkfb/winsdkfb/winsdkfb.Shared/FacebookSession.cpp
+++ b/winsdkfb/winsdkfb/winsdkfb.Shared/FacebookSession.cpp
@@ -231,7 +231,11 @@ IAsyncOperation<IStorageItem^>^ FBSession::MyTryGetItemAsync(
     {
         return create_task([=]() -> task<IStorageItem^>
         {
+#if defined(_WIN32_WINNT_WIN10)
+            return create_task(folder->TryGetItemAsync(itemName));
+#else
             return create_task(folder->GetItemAsync(itemName));
+#endif
         })
         .then([=](task<IStorageItem^> folderTask) -> IStorageItem^
         {


### PR DESCRIPTION
This minor tweak will remove the exception thrown when trying to find an existing FBSDKData file. Keep earlier behavior for WP8.1 compatibility