### PR TITLE
add picture to list of fields to query about initial user data

### DIFF
--- a/winsdkfb/winsdkfb/winsdkfb.Shared/FacebookSession.cpp
+++ b/winsdkfb/winsdkfb/winsdkfb.Shared/FacebookSession.cpp
@@ -210,7 +210,7 @@ task<FBResult^> FBSession::GetUserInfo(
 {
     PropertySet^ parameters = ref new PropertySet();
     parameters->Insert(L"fields",
-        L"gender,link,first_name,last_name,locale,timezone,email,updated_time,verified,name,id");
+        L"gender,link,first_name,last_name,locale,timezone,email,updated_time,verified,name,id,picture");
     FBSingleValue^ value = ref new FBSingleValue(
         "/me",
         parameters,


### PR DESCRIPTION
Upon logging in, some basic user data is queried and stored in an `FBUser` object that can be accessed from `FBSession`. One of these fields is metadata about the user's profile picture. This change explicitly queries for the profile picture data in cases where it is no longer provided by default.