### PR TITLE
Added fix for Facebook redirecting the webview to e.g. javascript app…

### DIFF
--- a/winsdkfb/winsdkfb/winsdkfb.Shared/FacebookDialog.xaml
+++ b/winsdkfb/winsdkfb/winsdkfb.Shared/FacebookDialog.xaml
@@ -28,7 +28,7 @@
                     MinWidth="0" MinHeight="0" Width="30" Height="30" 
                     Style="{StaticResource CircleWithCrossButtonKey}" Click="CloseDialogButton_OnClick" FontFamily="Segoe UI Symbol" 
                     Margin="0,0,0,5" Foreground="White" />
-            <WebView x:Name="dialogWebBrowser" Grid.Row="1" />
+            <WebView x:Name="dialogWebBrowser" Grid.Row="1" NavigationStarting="dialogWebBrowser_CancelClosedRedirects" />
         </Grid>
     </Grid>
 </UserControl>

--- a/winsdkfb/winsdkfb/winsdkfb.Shared/FacebookDialog.xaml.cpp
+++ b/winsdkfb/winsdkfb/winsdkfb.Shared/FacebookDialog.xaml.cpp
@@ -604,6 +604,17 @@ void FacebookDialog::dialogWebView_NavCompleted(
     }
 }
 
+void winsdkfb::FacebookDialog::dialogWebBrowser_CancelClosedRedirects(
+	Windows::UI::Xaml::Controls::WebView^ sender,
+	Windows::UI::Xaml::Controls::WebViewNavigationStartingEventArgs^ args
+	)
+{
+	if (!_popup || !_popup->IsOpen) { // ignore if Facebook tries to redirect webview after we have been closed
+		args->Cancel = true;
+	}
+}
+
+
 void FacebookDialog::CloseDialogButton_OnClick(
     Object^ sender,
     RoutedEventArgs^ e

--- a/winsdkfb/winsdkfb/winsdkfb.Shared/FacebookDialog.xaml.h
+++ b/winsdkfb/winsdkfb/winsdkfb.Shared/FacebookDialog.xaml.h
@@ -128,6 +128,11 @@ namespace winsdkfb
             Windows::UI::Xaml::Controls::WebViewNavigationCompletedEventArgs^ e
         );
 
+		void dialogWebBrowser_CancelClosedRedirects(
+			Windows::UI::Xaml::Controls::WebView^ sender,
+			Windows::UI::Xaml::Controls::WebViewNavigationStartingEventArgs^ args
+		);
+
         void CloseDialogButton_OnClick(
             Platform::Object^ sender, 
             Windows::UI::Xaml::RoutedEventArgs^ e
@@ -161,5 +166,5 @@ namespace winsdkfb
         Windows::UI::Xaml::Controls::Grid^ _grid;
         Windows::UI::Xaml::Controls::Primitives::Popup^ _popup;
         concurrency::task_completion_event<winsdkfb::FBResult^> _dialogResponse;
-    };
+};
 }


### PR DESCRIPTION
… pages after the dialog has been closed. This had the potential to lock the UI Thread due to javascript exceptions.