### PR TITLE
Add CurrentDataString to FacebookPaginatedArray

### DIFF
--- a/winsdkfb/winsdkfb/winsdkfb.Shared/FacebookPaginatedArray.cpp
+++ b/winsdkfb/winsdkfb/winsdkfb.Shared/FacebookPaginatedArray.cpp
@@ -40,6 +40,7 @@ FBPaginatedArray::FBPaginatedArray(
     winsdkfb::FBJsonClassFactory^ ObjectFactory
     ) :
     _current(nullptr),
+    _currentDataString(nullptr),
     _request(Request),
     _parameters(Parameters),
     _objectFactory(ObjectFactory)
@@ -92,6 +93,18 @@ IVectorView<Object^>^ FBPaginatedArray::Current::get()
     }
 
     return _current;
+}
+
+String^ FBPaginatedArray::CurrentDataString::get()
+{
+    IVectorView<Object^>^ result = nullptr;
+
+    if (!HasCurrent)
+    {
+        throw ref new InvalidArgumentException(SDKMessageBadCall);
+    }
+
+    return _currentDataString;
 }
 
 bool FBPaginatedArray::HasCurrent::get()
@@ -176,6 +189,7 @@ FBResult^ FBPaginatedArray::ConsumePagedResponse(
                             SDKMessageBadObject);
                     }
 
+                    _currentDataString = it->Current->Value->ToString();
                     _current = ObjectArrayFromJsonArray(
                         it->Current->Value->GetArray(), _objectFactory);
                     if (_current)

--- a/winsdkfb/winsdkfb/winsdkfb.Shared/FacebookPaginatedArray.h
+++ b/winsdkfb/winsdkfb/winsdkfb.Shared/FacebookPaginatedArray.h
@@ -111,6 +111,23 @@ namespace winsdkfb
             }
 
             /**
+            * The current collection of objects that were returned by a call
+            * to FirstAsync, NextAsync, or PreviousAsync. This is the raw string
+            * of the "data" value.
+            */
+            property Platform::String^
+                CurrentDataString
+            {
+                /**
+                * Gets the current collection of objects from the most recently
+                * queried page, in the raw string format.
+                * @exception InvalidArgumentException if no page is the current page.
+                * @returnPlatform::String^ of the data
+                */
+                Platform::String^ get();
+            }
+
+            /**
              * Indicates if the Graph call successfully returned a page of data
              * that was successfully converted by ObjectFactory.
              */
@@ -150,6 +167,7 @@ namespace winsdkfb
                 Platform::String^ path
                 );
 
+            Platform::String^ _currentDataString;
             Windows::Foundation::Collections::IVectorView<Object^>^ _current;
             FBPaging^ _paging;
             Platform::String^ _request;


### PR DESCRIPTION
This adds a field to FbPaginatedArray alongside with 'current', which is the data array. 

My scenario is that we are building a UWP app that needs to talk to a win32 process, they can only talk in strings through "AppServices". Once I have the data from FB, with this we don't have to translate the JsonArray back to String.