### PR TITLE
Support Facebook Gaming Graph Domain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ Packages.dgml
 Release
 sdk-build.log
 project.lock.json
+winsdkfb/winsdkfb_uwp/UpgradeLog.htm

--- a/samples/LoginCpp-UWP/LoginCpp/MainPage.xaml.cpp
+++ b/samples/LoginCpp-UWP/LoginCpp/MainPage.xaml.cpp
@@ -105,7 +105,7 @@ BOOL MainPage::DidGetAllRequestedPermissions(
     BOOL success = FALSE;
     FBAccessTokenData^ data = FBSession::ActiveSession->AccessTokenData;
 
-    if (data)
+    if (data && data->DeclinedPermissions)
     {
         success = !data->DeclinedPermissions->Values->Size;
     }

--- a/samples/LoginCpp-UWP/LoginCpp/Resources.resw
+++ b/samples/LoginCpp-UWP/LoginCpp/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="FBApplicationId" xml:space="preserve">
-    <value>2607649655979891</value>
+    <value>519296541448237</value>
     <comment>Facebook Application ID</comment>
   </data>
   <data name="FBWindowsAppId" xml:space="preserve">

--- a/samples/LoginCpp-UWP/LoginCpp/Resources.resw
+++ b/samples/LoginCpp-UWP/LoginCpp/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="FBApplicationId" xml:space="preserve">
-    <value>1606735379540755</value>
+    <value>2607649655979891</value>
     <comment>Facebook Application ID</comment>
   </data>
   <data name="FBWindowsAppId" xml:space="preserve">

--- a/winsdkfb/winsdkfb/winsdkfb.Shared/FacebookAccessTokenData.cpp
+++ b/winsdkfb/winsdkfb/winsdkfb.Shared/FacebookAccessTokenData.cpp
@@ -47,6 +47,9 @@ FBAccessTokenData::FBAccessTokenData(
 #ifdef _DEBUG
     DebugPrintExpirationTime();
 #endif
+
+	std::wstring wsAccessToken(AccessToken->Data());
+	_graphDomain = (wsAccessToken.substr(0, 2) == L"GG") ? L"gaming" : L"facebook";
 }
 
 FBAccessTokenData::FBAccessTokenData(
@@ -64,11 +67,19 @@ FBAccessTokenData::FBAccessTokenData(
     Vector<String^>^ v = ref new Vector<String^>(0);
     _grantedPermissions  = ref new FBPermissions(v->GetView());
     _declinedPermissions = ref new FBPermissions(v->GetView());
+
+	std::wstring wsAccessToken(AccessToken->Data());
+	_graphDomain = (wsAccessToken.substr(0, 2) == L"GG") ? L"gaming" : L"facebook";
 }
 
 String^ FBAccessTokenData::AccessToken::get()
 {
     return _accessToken;
+}
+
+String^ FBAccessTokenData::GraphDomain::get()
+{
+	return _graphDomain;
 }
 
 DateTime FBAccessTokenData::ExpirationDate::get()

--- a/winsdkfb/winsdkfb/winsdkfb.Shared/FacebookAccessTokenData.h
+++ b/winsdkfb/winsdkfb/winsdkfb.Shared/FacebookAccessTokenData.h
@@ -50,6 +50,14 @@ namespace winsdkfb
                 Platform::String^ get();
             }
 
+			/**
+			* Graph domain should be used for current access token.
+			*/
+			property Platform::String^ GraphDomain
+			{
+				Platform::String^ get();
+			}
+
             /**
              * Expiration date of the access token.
              */
@@ -119,6 +127,7 @@ namespace winsdkfb
 #endif
 
             Platform::String^ _accessToken;
+			Platform::String^ _graphDomain;
             Windows::Foundation::DateTime _expirationDate;
             FBPermissions^ _grantedPermissions;
             FBPermissions^ _declinedPermissions;

--- a/winsdkfb/winsdkfb/winsdkfb.Shared/FacebookClient.cpp
+++ b/winsdkfb/winsdkfb/winsdkfb.Shared/FacebookClient.cpp
@@ -398,8 +398,8 @@ Uri^ FBClient::PrepareRequestUri(
     PropertySet^ parameters
     )
 {
+	String^ graphDomain = L"facebook";
     FBSession^ sess = FBSession::ActiveSession;
-    GraphUriBuilder^ uriBuilder = ref new GraphUriBuilder(path);
 
     if (parameters == nullptr)
     {
@@ -427,11 +427,24 @@ Uri^ FBClient::PrepareRequestUri(
             sess->AccessTokenData->AccessToken);
     }
 
+	// For applications using Facebook Login for Gaming, graph API requests
+	// should be sent to different graph domain: graph.fb.gg
+	if (parametersWithoutMediaObjects->HasKey("access_token"))
+	{
+		String^ accessToken = safe_cast<String^>(parametersWithoutMediaObjects->Lookup("access_token"));
+		std::wstring wsAccessToken(accessToken->Data());
+		if ((wsAccessToken.substr(0, 2) == L"GG"))
+		{
+			graphDomain = L"gaming";
+		}
+	}
+
     if (parametersWithoutMediaObjects->HasKey("format"))
     {
         parametersWithoutMediaObjects->Insert("format", "json-strings");
     }
 
+	GraphUriBuilder^ uriBuilder = ref new GraphUriBuilder(path, graphDomain);
     SerializeParameters(parametersWithoutMediaObjects);
 
     // Add remaining parameters to query string.  Note that parameters that

--- a/winsdkfb/winsdkfb/winsdkfb.Shared/FacebookSession.cpp
+++ b/winsdkfb/winsdkfb/winsdkfb.Shared/FacebookSession.cpp
@@ -1334,7 +1334,9 @@ int FBSession::APIMinorVersion::get()
 void FBSession::SaveGrantedPermissions()
 {
     auto values =FBSession::DataContainer->Values;
-    values->Insert(GRANTED_PERMISSIONS_KEY, AccessTokenData->GrantedPermissions->ToString());
+	if (AccessTokenData->GrantedPermissions != nullptr) {
+		values->Insert(GRANTED_PERMISSIONS_KEY, this->_AccessTokenData->GrantedPermissions->ToString());
+	}
 }
 
 String^ FBSession::GetGrantedPermissions()

--- a/winsdkfb/winsdkfb/winsdkfb.Shared/FacebookSession.cpp
+++ b/winsdkfb/winsdkfb/winsdkfb.Shared/FacebookSession.cpp
@@ -209,8 +209,16 @@ task<FBResult^> FBSession::GetUserInfo(
     )
 {
     PropertySet^ parameters = ref new PropertySet();
-    parameters->Insert(L"fields",
-        L"gender,link,first_name,last_name,locale,timezone,email,updated_time,verified,name,id,picture");
+	if (TokenData->GraphDomain == L"gaming")
+	{
+		parameters->Insert(L"fields", L"link,email,name,id,picture");
+	}
+	else
+	{
+		parameters->Insert(L"fields",
+			L"gender,link,first_name,last_name,locale,timezone,email,updated_time,verified,name,id,picture");
+	}
+    
     FBSingleValue^ value = ref new FBSingleValue(
         "/me",
         parameters,

--- a/winsdkfb/winsdkfb/winsdkfb.Shared/GraphUriBuilder.cpp
+++ b/winsdkfb/winsdkfb/winsdkfb.Shared/GraphUriBuilder.cpp
@@ -27,7 +27,7 @@ using namespace Windows::Foundation::Collections;
 using namespace winsdkfb;
 
 
-GraphUriBuilder::GraphUriBuilder(String^ path)
+GraphUriBuilder::GraphUriBuilder(String^ path, String^ graphDomain)
     :
     _queryParams { ref new PropertySet() }
 {
@@ -45,6 +45,10 @@ GraphUriBuilder::GraphUriBuilder(String^ path)
     if (buildDomain)
     {
         String^ domain = L"https://graph.facebook.com/";
+		if (graphDomain == L"gaming")
+		{
+			domain = L"https://graph.fb.gg/";
+		}
         testUri = ref new Uri(domain + path);
     }
     _host = testUri->Host;

--- a/winsdkfb/winsdkfb/winsdkfb.Shared/GraphUriBuilder.h
+++ b/winsdkfb/winsdkfb/winsdkfb.Shared/GraphUriBuilder.h
@@ -23,7 +23,7 @@ namespace winsdkfb
     public ref class GraphUriBuilder sealed
     {
     public:
-        GraphUriBuilder(Platform::String^ path);
+		GraphUriBuilder(Platform::String^ path, Platform::String^ graphDomain);
 
         Windows::Foundation::Uri^ MakeUri();
         void AddQueryParam(Platform::String^ query, Platform::String^ param);


### PR DESCRIPTION
Facebook Gaming Graph Domain (graph.fb.gg) is a new domian dedicated for applications integrated with Facebook Login for Gaming. This change adds support in SDK to distinguish access token for FB or GG domain and make graph API calls accordingly.